### PR TITLE
Project create to use defaultApiVersion method for setting version

### DIFF
--- a/src/commands/force/project/create.ts
+++ b/src/commands/force/project/create.ts
@@ -75,11 +75,6 @@ export default class Project extends TemplateCommand {
     // namespace is a reserved keyword for the generator
     this.flags.ns = this.flags.namespace;
 
-    // TODO: update the latest apiversion
-    this.flags.sourceApiVersion = '47.0';
-
-    this.flags.loginURL = this.flags.loginurl;
-
     return this.runGenerator(ProjectGenerator);
   }
 }

--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -49,8 +49,8 @@ export default class ProjectGenerator extends generator {
       defaultpackagedir,
       manifest,
       ns,
-      sourceApiVersion,
-      loginURL
+      apiversion,
+      loginurl
     } = this.options;
     const folderlayout = [
       outputdir,
@@ -82,8 +82,8 @@ export default class ProjectGenerator extends generator {
       {
         defaultpackagedir,
         namespace: ns,
-        loginURL,
-        sourceApiVersion
+        loginurl,
+        apiversion
       }
     );
 
@@ -94,7 +94,7 @@ export default class ProjectGenerator extends generator {
         this.destinationPath(
           path.join(outputdir, projectname, 'manifest', 'package.xml')
         ),
-        { sourceApiVersion }
+        { apiversion }
       );
     }
 

--- a/src/templates/project/analytics/Manifest.xml
+++ b/src/templates/project/analytics/Manifest.xml
@@ -4,5 +4,5 @@
     <members>*</members>
     <name>WaveTemplateBundle</name>
   </types>
-  <version><%= sourceApiVersion %></version>
+  <version><%= apiversion %></version>
 </Package>

--- a/src/templates/project/empty/Manifest.xml
+++ b/src/templates/project/empty/Manifest.xml
@@ -32,5 +32,5 @@
         <members>*</members>
         <name>StaticResource</name>
     </types>
-    <version><%= sourceApiVersion %></version>
+    <version><%= apiversion %></version>
 </Package>

--- a/src/templates/project/sfdx-project.json
+++ b/src/templates/project/sfdx-project.json
@@ -1,11 +1,11 @@
 {
-    "packageDirectories": [
-      {
-        "path": "<%= defaultpackagedir %>",
-        "default": true
-      }
-    ],
-    "namespace": "<%= namespace %>",
-    "sfdcLoginUrl": "<%= loginURL %>",
-    "sourceApiVersion": "<%= sourceApiVersion %>"
-  }
+  "packageDirectories": [
+    {
+      "path": "<%= defaultpackagedir %>",
+      "default": true
+    }
+  ],
+  "namespace": "<%= namespace %>",
+  "sfdcLoginUrl": "<%= loginurl %>",
+  "sourceApiVersion": "<%= apiversion %>"
+}

--- a/src/templates/project/standard/Manifest.xml
+++ b/src/templates/project/standard/Manifest.xml
@@ -32,5 +32,5 @@
         <members>*</members>
         <name>StaticResource</name>
     </types>
-    <version><%= sourceApiVersion %></version>
+    <version><%= apiversion %></version>
 </Package>


### PR DESCRIPTION
### What does this PR do?

Updates project:create to use the api version method to get the version instead of relying on the hardcoded value 47.0.

### What issues does this PR fix or reference?

W-6825719
