### PR TITLE
Ensure LWC class name is the same as the value passed with the name flag

### DIFF
--- a/src/commands/force/lightning/component/create.ts
+++ b/src/commands/force/lightning/component/create.ts
@@ -83,13 +83,6 @@ export default class LightningComponent extends TemplateCommand {
     CreateUtil.checkInputs(this.flags.componentname);
     CreateUtil.checkInputs(this.flags.template);
 
-    // lwc requires first letter lowercase
-    if (this.flags.type === 'lwc') {
-      this.flags.componentname = `${this.flags.componentname
-        .substring(0, 1)
-        .toLowerCase()}${this.flags.componentname.substring(1)}`;
-    }
-
     const fileparts = path.resolve(this.flags.outputdir).split(path.sep);
 
     if (!this.flags.internal) {

--- a/src/generators/lightningComponentGenerator.ts
+++ b/src/generators/lightningComponentGenerator.ts
@@ -95,27 +95,30 @@ export default class LightningComponentGenerator extends generator {
     }
     // tslint:disable-next-line:no-unused-expression
     if (type === 'lwc') {
+      // lwc requires first letter of filename to be lowercase
+      const fileName = `${componentname
+        .substring(0, 1)
+        .toLowerCase()}${componentname.substring(1)}`;
+
       this.sourceRoot(
         path.join(__dirname, '..', 'templates', 'lightningcomponent', 'lwc')
       );
       this.fs.copyTpl(
         this.templatePath('DefaultLightningLWC.js'),
-        this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.js`)
-        ),
+        this.destinationPath(path.join(outputdir, fileName, `${fileName}.js`)),
         { componentname }
       ),
         this.fs.copyTpl(
           this.templatePath('_.html'),
           this.destinationPath(
-            path.join(outputdir, componentname, `${componentname}.html`)
+            path.join(outputdir, fileName, `${fileName}.html`)
           )
         );
       if (!internal) {
         this.fs.copyTpl(
           this.templatePath('_js-meta.xml'),
           this.destinationPath(
-            path.join(outputdir, componentname, `${componentname}.js-meta.xml`)
+            path.join(outputdir, fileName, `${fileName}.js-meta.xml`)
           ),
           { apiVersion: apiversion, componentname }
         );

--- a/src/generators/lightningComponentGenerator.ts
+++ b/src/generators/lightningComponentGenerator.ts
@@ -120,7 +120,7 @@ export default class LightningComponentGenerator extends generator {
           this.destinationPath(
             path.join(outputdir, fileName, `${fileName}.js-meta.xml`)
           ),
-          { apiVersion: apiversion, componentname }
+          { apiVersion: apiversion }
         );
       }
     }

--- a/test/commands/lightning/component/create.test.ts
+++ b/test/commands/lightning/component/create.test.ts
@@ -70,7 +70,18 @@ describe('Lightning component creation tests:', () => {
         'lwc'
       ])
       .it('should force first letter of component name to lowercase', ctx => {
-        assert.file(path.join('lwc', 'fooBar'));
+        const camelCaseName = 'fooBar';
+        const bundlePath = path.join('lwc', camelCaseName);
+        const jsPath = path.join(bundlePath, `${camelCaseName}.js`);
+        assert.file(bundlePath);
+        assert.file(jsPath);
+        assert.file(path.join(bundlePath, `${camelCaseName}.html`));
+        assert.file(path.join(bundlePath, `${camelCaseName}.js-meta.xml`));
+        // but verify the class name is consistent with the exact flag value
+        assert.fileContent(
+          jsPath,
+          'export default class FooBar extends LightningElement {}'
+        );
       });
 
     test


### PR DESCRIPTION
### What does this PR do?

Update LWC generation so that only the filenames are camelCased, while the class name stays consistent with what the user enters for the name flag.

### What issues does this PR fix or reference?
