### PR TITLE
LWC js class name should always be pascal case

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,16 @@
 {
-    "files.exclude": {
-      "**/.git": true,
-      "**/.svn": true,
-      "**/.hg": true,
-      "**/CVS": true,
-      "**/.DS_Store": true
-    },
-    "search.exclude": {
-      "**/lib": true,
-      "**/bin": true
-    },
-    "editor.tabSize": 2,
-    "editor.formatOnSave": true,
-    "prettier.singleQuote": true,
-    "rewrap.wrappingColumn": 80
-  }
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true
+  },
+  "search.exclude": {
+    "**/lib": true,
+    "**/bin": true
+  },
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "rewrap.wrappingColumn": 80
+}

--- a/src/commands/force/lightning/component/create.ts
+++ b/src/commands/force/lightning/component/create.ts
@@ -83,6 +83,13 @@ export default class LightningComponent extends TemplateCommand {
     CreateUtil.checkInputs(this.flags.componentname);
     CreateUtil.checkInputs(this.flags.template);
 
+    if (this.flags.type === 'lwc') {
+      // lwc's convention is for the class name to be Pascal Case
+      this.flags.componentname = `${this.flags.componentname
+        .substring(0, 1)
+        .toUpperCase()}${this.flags.componentname.substring(1)}`;
+    }
+
     const fileparts = path.resolve(this.flags.outputdir).split(path.sep);
 
     if (!this.flags.internal) {

--- a/src/commands/force/lightning/component/create.ts
+++ b/src/commands/force/lightning/component/create.ts
@@ -83,13 +83,6 @@ export default class LightningComponent extends TemplateCommand {
     CreateUtil.checkInputs(this.flags.componentname);
     CreateUtil.checkInputs(this.flags.template);
 
-    if (this.flags.type === 'lwc') {
-      // lwc's convention is for the class name to be Pascal Case
-      this.flags.componentname = `${this.flags.componentname
-        .substring(0, 1)
-        .toUpperCase()}${this.flags.componentname.substring(1)}`;
-    }
-
     const fileparts = path.resolve(this.flags.outputdir).split(path.sep);
 
     if (!this.flags.internal) {

--- a/src/generators/lightningComponentGenerator.ts
+++ b/src/generators/lightningComponentGenerator.ts
@@ -100,13 +100,18 @@ export default class LightningComponentGenerator extends generator {
         .substring(0, 1)
         .toLowerCase()}${componentname.substring(1)}`;
 
+      // lwc's convention is for the class name to be Pascal Case
+      const className = `${componentname
+        .substring(0, 1)
+        .toUpperCase()}${componentname.substring(1)}`;
+
       this.sourceRoot(
         path.join(__dirname, '..', 'templates', 'lightningcomponent', 'lwc')
       );
       this.fs.copyTpl(
         this.templatePath('DefaultLightningLWC.js'),
         this.destinationPath(path.join(outputdir, fileName, `${fileName}.js`)),
-        { componentname }
+        { className }
       ),
         this.fs.copyTpl(
           this.templatePath('_.html'),

--- a/src/templates/lightningcomponent/lwc/DefaultLightningLWC.js
+++ b/src/templates/lightningcomponent/lwc/DefaultLightningLWC.js
@@ -1,3 +1,3 @@
 import { LightningElement } from 'lwc';
 
-export default class <%= componentname %> extends LightningElement {}
+export default class <%= className %> extends LightningElement {}

--- a/test/commands/force/lightning/component/create.test.ts
+++ b/test/commands/force/lightning/component/create.test.ts
@@ -120,7 +120,7 @@ describe('Lightning component creation tests:', () => {
           );
           assert.fileContent(
             path.join('lwc', 'internallwctest', 'internallwctest.js'),
-            'export default class internallwctest extends LightningElement {}'
+            'export default class Internallwctest extends LightningElement {}'
           );
         }
       );

--- a/test/commands/lightning/component/create.test.ts
+++ b/test/commands/lightning/component/create.test.ts
@@ -105,7 +105,7 @@ describe('Lightning component creation tests:', () => {
           assert.file(path.join('lwc', 'foo', 'foo.js'));
           assert.fileContent(
             path.join('lwc', 'foo', 'foo.js'),
-            'export default class foo extends LightningElement {}'
+            'export default class Foo extends LightningElement {}'
           );
         }
       );


### PR DESCRIPTION
### What does this PR do?
Follow up to PR #52 to address scenarios where `--componentname` value is camelCase and js class name should be pascal case.

### What issues does this PR fix or reference?
#53  , @W-6902712@