### PR TITLE
Fix example typo for lightning event

### DIFF
--- a/src/commands/force/lightning/event/create.ts
+++ b/src/commands/force/lightning/event/create.ts
@@ -20,7 +20,7 @@ export default class LightningEvent extends TemplateCommand {
     [BUNDLE_TYPE]
   );
   public static examples = [
-    '$ sfdx force:lightning:app:create -n myevent',
+    '$ sfdx force:lightning:event:create -n myevent',
     '$ sfdx force:lightning:event:create -n myevent -d aura'
   ];
   public static help = MessageUtil.buildHelpText(LightningEvent.examples, true);


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in one of the examples for lightning:event:create

### What issues does this PR fix or reference?

W-6826538