### PR TITLE
[Port #58] Fix example typo for lightning event

### DIFF
--- a/src/commands/force/lightning/event/create.ts
+++ b/src/commands/force/lightning/event/create.ts
@@ -20,7 +20,7 @@ export default class LightningEvent extends TemplateCommand {
     [BUNDLE_TYPE]
   );
   public static examples = [
-    '$ sfdx force:lightning:app:create -n myevent',
+    '$ sfdx force:lightning:event:create -n myevent',
     '$ sfdx force:lightning:event:create -n myevent -d aura'
   ];
   public static help = MessageUtil.buildHelpText(LightningEvent.examples, true);


### PR DESCRIPTION
(cherry picked from commit 9267b22523b9e63fcdbad24454a8cdeb69128bdd)
