### PR TITLE
project:create help should not show incorrect default directory @W-64…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build the plugin locally, make sure to have yarn installed and run the follow
 
 ```
 Clone the repository
-  $ git clone git@github.com:forcedotcom/salesforcedx-vscode.git
+  $ git clone git@github.com:forcedotcom/salesforcedx-templates.git
 Install the dependencies and compile
   $ yarn install
   $ yarn prepack

--- a/src/commands/force/project/create.ts
+++ b/src/commands/force/project/create.ts
@@ -41,7 +41,7 @@ export default class Project extends TemplateCommand {
       char: 'd',
       description: MessageUtil.get('OutputDirFlagDescription'),
       longDescription: MessageUtil.get('OutputDirFlagLongDescription'),
-      default: process.cwd()
+      default: '.'
     }),
     namespace: flags.string({
       char: 's',


### PR DESCRIPTION
…91472@

### What does this PR do?
Shows "." as the default directory where the project would be created for the command "sfdx force:project:create --help". The actual project creation logic stays the same.
Fixed a typo in the README.md file.

### What issues does this PR fix or reference?
"sfdx force:project:create --help" currently shows "/Users/jason.grantham/source/templates/salesforcedx-templates" as the default directory.
