### PR TITLE
sfdx force:project:create should not create a duplicate project in th…

### DIFF
--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -185,8 +185,8 @@ function makeEmptyFolders(
   for (const folder of toplevelfolders) {
     if (!fs.existsSync(path.join(oldfolder, folder))) {
       fs.mkdirSync(path.join(oldfolder, folder));
-      oldfolder = path.join(oldfolder, folder);
     }
+    oldfolder = path.join(oldfolder, folder);
   }
   for (const newfolder of metadatafolders) {
     if (!fs.existsSync(path.join(oldfolder, newfolder))) {

--- a/test/commands/project/create.test.ts
+++ b/test/commands/project/create.test.ts
@@ -161,6 +161,27 @@ describe('Project creation tests:', () => {
       .withOrg()
       .withProject()
       .stdout()
+      .command([
+        'force:project:create',
+        '--projectname',
+        'duplicate-project-test',
+        '--outputdir',
+        'test outputdir'
+      ])
+      .it(
+        'should not create duplicate project in the directory where command is executed',
+        ctx => {
+          assert.file(
+            path.join('test outputdir', 'duplicate-project-test', 'force-app')
+          );
+          assert.noFile(path.join('.', 'duplicate-project-test', 'force-app'));
+        }
+      );
+
+    test
+      .withOrg()
+      .withProject()
+      .stdout()
       .command(['force:project:create', '--projectname', 'foo-project'])
       .it(
         'should create project with default values and foo-project name in a custom output directory with spaces in its name',


### PR DESCRIPTION
…e working directory  @W-7094617@

### What does this PR do?
Currently "sfdx force:project:create" creates a duplicate empty project structure in the working directory where the command was issued. This PR fixes that issues.

### What issues does this PR fix or reference?
W-7094617