### PR TITLE
Jj/port duplicate project bug fix to release @W-7094617@

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build the plugin locally, make sure to have yarn installed and run the follow
 
 ```
 Clone the repository
-  $ git clone git@github.com:forcedotcom/salesforcedx-vscode.git
+  $ git clone git@github.com:forcedotcom/salesforcedx-templates.git
 Install the dependencies and compile
   $ yarn install
   $ yarn prepack

--- a/src/commands/force/lightning/event/create.ts
+++ b/src/commands/force/lightning/event/create.ts
@@ -20,7 +20,7 @@ export default class LightningEvent extends TemplateCommand {
     [BUNDLE_TYPE]
   );
   public static examples = [
-    '$ sfdx force:lightning:app:create -n myevent',
+    '$ sfdx force:lightning:event:create -n myevent',
     '$ sfdx force:lightning:event:create -n myevent -d aura'
   ];
   public static help = MessageUtil.buildHelpText(LightningEvent.examples, true);

--- a/src/commands/force/project/create.ts
+++ b/src/commands/force/project/create.ts
@@ -41,7 +41,7 @@ export default class Project extends TemplateCommand {
       char: 'd',
       description: MessageUtil.get('OutputDirFlagDescription'),
       longDescription: MessageUtil.get('OutputDirFlagLongDescription'),
-      default: process.cwd()
+      default: '.'
     }),
     namespace: flags.string({
       char: 's',

--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -185,8 +185,8 @@ function makeEmptyFolders(
   for (const folder of toplevelfolders) {
     if (!fs.existsSync(path.join(oldfolder, folder))) {
       fs.mkdirSync(path.join(oldfolder, folder));
-      oldfolder = path.join(oldfolder, folder);
     }
+    oldfolder = path.join(oldfolder, folder);
   }
   for (const newfolder of metadatafolders) {
     if (!fs.existsSync(path.join(oldfolder, newfolder))) {

--- a/test/commands/project/create.test.ts
+++ b/test/commands/project/create.test.ts
@@ -161,6 +161,27 @@ describe('Project creation tests:', () => {
       .withOrg()
       .withProject()
       .stdout()
+      .command([
+        'force:project:create',
+        '--projectname',
+        'duplicate-project-test',
+        '--outputdir',
+        'test outputdir'
+      ])
+      .it(
+        'should not create duplicate project in the directory where command is executed',
+        ctx => {
+          assert.file(
+            path.join('test outputdir', 'duplicate-project-test', 'force-app')
+          );
+          assert.noFile(path.join('.', 'duplicate-project-test', 'force-app'));
+        }
+      );
+
+    test
+      .withOrg()
+      .withProject()
+      .stdout()
       .command(['force:project:create', '--projectname', 'foo-project'])
       .it(
         'should create project with default values and foo-project name in a custom output directory with spaces in its name',


### PR DESCRIPTION
### What does this PR do?
Currently "sfdx force:project:create" creates a duplicate empty project structure in the working directory where the command was issued. This PR fixes that issues.

### What issues does this PR fix or reference?
W-7094617