### PR TITLE
Remove references to conflicter

### DIFF
--- a/src/generators/apexClassGenerator.ts
+++ b/src/generators/apexClassGenerator.ts
@@ -12,8 +12,6 @@ export default class ApexClassGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'apexclass'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
 
   public writing() {

--- a/src/generators/apexTriggerGenerator.ts
+++ b/src/generators/apexTriggerGenerator.ts
@@ -11,8 +11,6 @@ export default class ApexTriggerGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'apextrigger'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const {

--- a/src/generators/lightningAppGenerator.ts
+++ b/src/generators/lightningAppGenerator.ts
@@ -16,8 +16,6 @@ export default class LightningAppGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'lightningapp'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const { template, outputdir, appname, apiversion, internal } = this.options;

--- a/src/generators/lightningComponentGenerator.ts
+++ b/src/generators/lightningComponentGenerator.ts
@@ -15,8 +15,6 @@ const messages = Messages.loadMessages('salesforcedx-templates', 'messages');
 export default class LightningComponentGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const {

--- a/src/generators/lightningEventGenerator.ts
+++ b/src/generators/lightningEventGenerator.ts
@@ -16,8 +16,6 @@ export default class LightningEventGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'lightningevent'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const {

--- a/src/generators/lightningInterfaceGenerator.ts
+++ b/src/generators/lightningInterfaceGenerator.ts
@@ -18,8 +18,6 @@ export default class LightningInterfaceGenerator extends Generator {
     this.sourceRoot(
       path.join(__dirname, '..', 'templates', 'lightninginterface')
     );
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const {

--- a/src/generators/lightningTestGenerator.ts
+++ b/src/generators/lightningTestGenerator.ts
@@ -16,8 +16,6 @@ export default class LightningTestGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'lightningtest'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const { template, outputdir, testname, internal } = this.options;

--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -40,8 +40,6 @@ export default class ProjectGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'project'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
   public writing() {
     const {

--- a/src/generators/visualforceComponentGenerator.ts
+++ b/src/generators/visualforceComponentGenerator.ts
@@ -14,8 +14,6 @@ export default class VisualforceComponentGenerator extends Generator {
     this.sourceRoot(
       path.join(__dirname, '..', 'templates', 'visualforcecomponent')
     );
-    // @ts-ignore
-    this.conflicter.force = false;
   }
 
   public writing() {

--- a/src/generators/visualforcePageGenerator.ts
+++ b/src/generators/visualforcePageGenerator.ts
@@ -6,8 +6,6 @@ export default class VisualforcePageGenerator extends Generator {
   constructor(args: string | string[], options: OptionsMap) {
     super(args, options);
     this.sourceRoot(path.join(__dirname, '..', 'templates', 'visualforcepage'));
-    // @ts-ignore
-    this.conflicter.force = false;
   }
 
   public writing() {


### PR DESCRIPTION
### What does this PR do?
This PR removes all references to the conflicter. The conflicter was originally referenced to ensure that the generator recognizes when there is a conflict but does not give the user a prompt before overwriting any files that conflict with pre-existing files. Now, the default behavior by yeoman is our desired behavior (recognize & overwrite without prompt) so there is no need to reference the conflicter.

If we want to change this behavior in the future, we would have to create a new Conflicter class and set our desired behavior.

### What issues does this PR fix or reference?
@W-7481052@