### PR TITLE
Updates for analytics project and sample template

### DIFF
--- a/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/dashboards/basicDashboard.json
+++ b/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/dashboards/basicDashboard.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= templateName %>Dashboard",
+  "name": "<%= templateName %>Dashboard_tp",
   "label": "<%= templateName %>Dashboard",
   "description": "<%= templateName %> dashboard",
   "folder": {

--- a/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
+++ b/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
@@ -3,7 +3,7 @@
   "label": "<%= templateName %>",
   "name": "<%= templateName %>",
   "description": "",
-  "assetVersion": <%= sourceApiVersion %>,
+  "assetVersion": 48.0,
   "variableDefinition": "variables.json",
   "uiDefinition": "ui.json",
   "rules": [

--- a/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
+++ b/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
@@ -26,7 +26,7 @@
   "dashboards": [
     {
       "label": "<%= templateName %>Dashboard",
-      "name": "<%= templateName %>Dashboard",
+      "name": "<%= templateName %>Dashboard_tp",
       "condition": "${Variables.Overrides.createAllDashboards}",
       "file": "dashboards/<%= templateName %>Dashboard.json"
     }

--- a/src/templates/project/analytics/ScratchDef.json
+++ b/src/templates/project/analytics/ScratchDef.json
@@ -1,5 +1,20 @@
 {
   "orgName": "<%= company %>",
   "edition": "Developer",
-  "features": ["DevelopmentWave"]
+  "features": [
+    "DevelopmentWave"
+  ],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "securitySettings": {
+      "passwordPolicies": {
+        "enableSetPasswordInApi": true
+      }
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    }
+  }
 }

--- a/test/commands/force/analytics/template/create.test.ts
+++ b/test/commands/force/analytics/template/create.test.ts
@@ -45,7 +45,7 @@ describe('Analytics template creation tests:', () => {
               'dashboards',
               'fooDashboard.json'
             ),
-            '"name": "fooDashboard"'
+            '"name": "fooDashboard_tp"'
           );
         }
       );

--- a/test/commands/project/create.test.ts
+++ b/test/commands/project/create.test.ts
@@ -362,7 +362,7 @@ describe('Project creation tests:', () => {
           }
           assert.fileContent(
             path.join('analytics1', 'config', 'project-scratch-def.json'),
-            '["DevelopmentWave"]'
+            '"DevelopmentWave"'
           );
           assert.fileContent(
             path.join('analytics1', 'manifest', 'package.xml'),


### PR DESCRIPTION
- Add the dev productivity settings (from #110) to the analytics project scratch-def.json
- Hardcode the assetVersion in the analytics to 48.0 to match the format of the dashboard in the template
- Include the `_tp` name suffix on the sample analytics template dashboard, to support it being used in multiple embedded analytics app in the server