### PR TITLE
Fix for node requirement & .yo-repository directory generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-staged": "^10.2.2",
     "mkdirp": "^0.5.1",
     "tslib": "^1",
-    "yeoman-environment": "^2.9.0",
+    "yeoman-environment": "2.8.1",
     "yeoman-generator": "4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### What does this PR do?
This PR addresses the issues of requiring Node to be installed locally for the end user and creating an empty `.yo-repository` folder in the directory the command was run from. It looks like this issue was introduced by Yeoman release 2.8.1 as an experimental feature.

### What issues does this PR fix or reference?

