### PR TITLE
Fix for node requirement & .yo-repository directory generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-staged": "^10.2.2",
     "mkdirp": "^0.5.1",
     "tslib": "^1",
-    "yeoman-environment": "^2.9.0",
+    "yeoman-environment": "2.4.0",
     "yeoman-generator": "4.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5441,29 +5441,26 @@ yeoman-assert@^3.1.1:
   resolved "https://registry.yarnpkg.com/yeoman-assert/-/yeoman-assert-3.1.1.tgz#9f6fa0ecba7dd007c40f579668cb5dda18c79343"
   integrity sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ==
 
-yeoman-environment@^2.3.4, yeoman-environment@^2.8.1, yeoman-environment@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.9.0.tgz#de64a88100fcd0d33bf8816fa04d8a69f2b8945b"
-  integrity sha512-wPbGhMyO1iVCis5+vSteQObRMpQ8O2eoINUEvCivDqjm29X2bTyLYyg1EIkysJsYysFskFuszOfXDwDe/Q3MTA==
+yeoman-environment@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.4.0.tgz#4829445dc1306b02d9f5f7027cd224bf77a8224d"
+  integrity sha512-SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==
   dependencies:
     chalk "^2.4.1"
+    cross-spawn "^6.0.5"
     debug "^3.1.0"
     diff "^3.5.0"
     escape-string-regexp "^1.0.2"
-    execa "^4.0.0"
     globby "^8.0.1"
-    grouped-queue "^1.0.0"
-    inquirer "^7.1.0"
+    grouped-queue "^0.3.3"
+    inquirer "^6.0.0"
     is-scoped "^1.0.0"
     lodash "^4.17.10"
     log-symbols "^2.2.0"
     mem-fs "^1.1.0"
-    mem-fs-editor "^6.0.0"
-    semver "^7.1.3"
     strip-ansi "^4.0.0"
     text-table "^0.2.0"
     untildify "^3.0.3"
-    yeoman-generator "^4.7.2"
 
 yeoman-generator@4.0.1:
   version "4.0.1"


### PR DESCRIPTION
### What does this PR do?
This PR addresses the issues of requiring Node to be installed locally for the end user and creating an empty .yo-repository folder in the directory the command was run from. It looks like this issue was introduced by Yeoman release 2.8.1 as an experimental feature. This PR reverts the version of Yeoman back down to the latest one we had previously released with the plugin.
We've reached out to yeoman on this issue here: https://github.com/yeoman/environment/issues/227

### What issues does this PR fix or reference?
@W-7554801@
