### PR TITLE
changed prettier versions to major only

### DIFF
--- a/src/templates/project/package.json
+++ b/src/templates/project/package.json
@@ -19,7 +19,7 @@
     "@salesforce/eslint-config-lwc": "^0.5.0",
     "@salesforce/sfdx-lwc-jest": "^0.7.1",
     "eslint": "^6.8.0",
-    "prettier": "^2.0.5",
-    "prettier-plugin-apex": "^1.4.0"
+    "prettier": "^2",
+    "prettier-plugin-apex": "^1"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Less restrictive version numbers on prettier and plugins
