### PR TITLE
Removed semicolon on soql example

### DIFF
--- a/src/templates/project/standard/account.soql
+++ b/src/templates/project/standard/account.soql
@@ -3,4 +3,4 @@
 //     query text and running the command:
 //     SFDX: Execute SOQL Query with Currently Selected Text
 
-SELECT Id, Name FROM Account;
+SELECT Id, Name FROM Account


### PR DESCRIPTION
The semi-colon isnt needed when you select and run the query.

### What does this PR do?

### What issues does this PR fix or reference?
@W-7654878@