### PR TITLE
chore: update to v49

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforcedx-templates",
   "description": "Salesforce CLI scaffolding commands for different types of Force.com metadata",
-  "version": "48.8.0",
+  "version": "49.0.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?
Update the version to v49 after R2
