### PR TITLE
add known host config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ commands:
       - add_ssh_keys:
           fingerprints:
             - << pipeline.parameters.fingerprint >>
+      - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
 jobs:
   node-latest: &test


### PR DESCRIPTION
### What does this PR do?
Adding github to authenticated host, since we didn't `checkout` in the job where we pushes the git tags
https://circleci.com/docs/2.0/gh-bb-integration/#establishing-the-authenticity-of-an-ssh-host
