### PR TITLE
Remove @salesforce/templates

### DIFF
--- a/packages/plugin-templates/yarn.lock
+++ b/packages/plugin-templates/yarn.lock
@@ -435,16 +435,6 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.0.1.tgz#d1db56759d2b22a7688e1821aec564e979237ad2"
   integrity sha512-78pP1GB/DbIS8nSWGL0GpQ27g02drrEo0vzYdRipGYAIXHMzlh1gqEsq0pOiIQlPm1MxWyEqbmf4GG5qSVsd0Q==
 
-"@salesforce/templates@49.4.4":
-  version "49.4.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-49.4.4.tgz#6d93cba7355c08d46ec26ec9b9d5ee790aab5432"
-  integrity sha512-7uDI59iTusshF6L+IGNmjeE3TkYR7fGo6AR1kbp6urfX8gvig8G7U+o0UaeyAhXSHQIzgptitf2TI/5lOcfb4A==
-  dependencies:
-    "@salesforce/core" "^2.3.0"
-    tslib "^1"
-    yeoman-environment "2.4.0"
-    yeoman-generator "4.0.1"
-
 "@salesforce/ts-sinon@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.2.2.tgz#4d99437def324f9e5507a02c3b322a40ed769167"


### PR DESCRIPTION
### What does this PR do?
Remove @salesforce/templates from yarn.lock to prevent getting the code from npm when developing the repo

### What issues does this PR fix or reference?
@W-8017763@