### PR TITLE
Update analytics dashboard json format

### DIFF
--- a/packages/plugin-templates/test/commands/force/analytics/template/create.test.ts
+++ b/packages/plugin-templates/test/commands/force/analytics/template/create.test.ts
@@ -25,24 +25,40 @@ describe('Analytics template creation tests:', () => {
       .it(
         'should create analytics template foo using foo as the output name and internal values',
         ctx => {
-          assert.file('waveTemplates/foo/template-info.json');
-          assert.fileContent(
+          assert.jsonFileContent(
             path.join('waveTemplates', 'foo', 'template-info.json'),
-            '"label": "foo"'
+            {
+              label: 'foo',
+              assetVersion: 49.0
+            }
           );
-          assert.fileContent(
+
+          assert.jsonFileContent(
             path.join('waveTemplates', 'foo', 'folder.json'),
-            '"name": "foo"'
+            { name: 'foo' }
           );
-          assert.file('waveTemplates/foo/dashboards/fooDashboard.json');
-          assert.fileContent(
+
+          assert.jsonFileContent(
             path.join(
               'waveTemplates',
               'foo',
               'dashboards',
               'fooDashboard.json'
             ),
-            '"name": "fooDashboard_tp"'
+            {
+              name: 'fooDashboard_tp',
+              state: {
+                widgets: {
+                  text_1: {
+                    parameters: {
+                      content: {
+                        displayTemplate: 'foo Analytics Dashboard'
+                      }
+                    }
+                  }
+                }
+              }
+            }
           );
         }
       );

--- a/packages/templates/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/dashboards/basicDashboard.json
+++ b/packages/templates/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/dashboards/basicDashboard.json
@@ -68,9 +68,11 @@
     "widgets": {
       "text_1": {
         "parameters": {
+          "content": {
+            "displayTemplate": "<%= templateName %> Analytics Dashboard"
+          },
           "fontSize": 48,
           "showActionMenu": true,
-          "text": "<%= templateName %> Analytics Dashboard",
           "textAlignment": "center",
           "textColor": "rgb(9, 26, 62)"
         },

--- a/packages/templates/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
+++ b/packages/templates/src/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-info.json
@@ -3,7 +3,7 @@
   "label": "<%= templateName %>",
   "name": "<%= templateName %>",
   "description": "",
-  "assetVersion": 48.0,
+  "assetVersion": 49.0,
   "variableDefinition": "variables.json",
   "uiDefinition": "ui.json",
   "rules": [


### PR DESCRIPTION
In 49.0, the json for analytics dashboards changed a bit. Now that all customers
have been on 49.0 for awhile, this updates the sample analytics template to the
new format.
