### PR TITLE
chore: add ability to provide custom version to publish (@W-8148526)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ parameters:
   publish-type:
     type: string
     default: minor
+  publish-version:
+    type: string
+    default: ''
 
 commands:
   setup-publish:
@@ -40,7 +43,17 @@ commands:
       - run:
           name: Bump package version
           command: |
-            npx lerna version << pipeline.parameters.publish-type >> --force-publish --no-git-tag-version --exact --yes
+            if [ ! -z << pipeline.parameters.publish-version >> ]; then
+              if [[ << pipeline.parameters.publish-version >> =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+                echo "Publish version << pipeline.parameters.publish-version >> is valid."
+                npx lerna version << pipeline.parameters.publish-version >> --force-publish --no-git-tag-version --exact --yes
+              else
+                echo "Publish version << pipeline.parameters.publish-version >> does not fit the format xx.yy.zz. Exiting."
+                exit 1
+              fi
+            else
+              npx lerna version << pipeline.parameters.publish-type >> --force-publish --no-git-tag-version --exact --yes
+            fi
             git add .
             export RELEASE_TAG="$(node -pe "require('./lerna.json').version")"
             git commit -m "Updated version $RELEASE_TAG"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,10 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": ["run", "build"],
+      "args": [
+        "run",
+        "build"
+      ],
       "isBackground": false,
       "problemMatcher": {
         "owner": "typescript",
@@ -38,7 +41,10 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": ["run", "lint"],
+      "args": [
+        "run",
+        "lint"
+      ],
       "isBackground": false,
       "problemMatcher": {
         "owner": "typescript",
@@ -57,7 +63,11 @@
       "label": "Publish Library and Plugin",
       "command": "./scripts/publish-workflow.sh",
       "type": "shell",
-      "args": ["${input:circleCiId}", "${input:publishType}"]
+      "args": [
+        "${input:circleCiId}",
+        "${input:publishType}",
+        "${input:publishVersion}"
+      ]
     }
   ],
   "inputs": [
@@ -70,8 +80,17 @@
       "id": "publishType",
       "type": "pickString",
       "description": "Type of version to publish",
-      "options": ["minor", "patch", "major"],
+      "options": [
+        "minor",
+        "patch",
+        "major"
+      ],
       "default": "minor"
+    },
+    {
+      "id": "publishVersion",
+      "type": "promptString",
+      "description": "Enter a custom version? Leave blank to use the default logic."
     }
   ]
 }

--- a/scripts/publish-workflow.sh
+++ b/scripts/publish-workflow.sh
@@ -5,11 +5,23 @@
 
 CircleCIToken=$1
 PublishType=$2
+PublishVersion=$3
+
+if [ ! -z "${PublishVersion}" ]; then
+  if [[ "${PublishVersion}" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+    echo "Publish version ${PublishVersion} is valid."
+  else
+    echo "Publish version ${PublishVersion} does not fit the format xx.yy.zz. Exiting."
+    exit 1
+  fi
+fi
+
 curl -v -u ${CircleCIToken}: -X POST --header "Content-Type: application/json" -d '{
   "branch": "main",
   "parameters": {
     "publish": true,
-    "publish-type": "'"${PublishType}"'"
+    "publish-type": "'"${PublishType}"'",
+    "publish-version": "'"${PublishVersion}"'"
   }
 }' https://circleci.com/api/v2/project/gh/forcedotcom/salesforcedx-templates/pipeline
 


### PR DESCRIPTION
### What does this PR do?
In order to ensure that we have the same version as VSCode Extensions, provide the ability to specify a version to publish.

### What issues does this PR fix or reference?
@W-8148526@
