### PR TITLE
chore: add context restriction for publish-workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ workflows:
       - hold: # Requires manual approval in Circle Ci
           type: approval
       - publish-library:
+          context: pdt-publish-restricted-context
           filters:
             branches:
               only:
@@ -230,6 +231,7 @@ workflows:
             - prepublish
             - hold
       - publish-plugin:
+          context: pdt-publish-restricted-context
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,14 +213,16 @@ workflows:
       - node-12
       - node-10
       - run-win-tests
+      - hold: # Requires manual approval in Circle Ci
+          type: approval
       - prepublish:
+          context: pdt-publish-restricted-context
           requires:
             - run-win-tests
             - node-latest
             - node-12
             - node-10
-      - hold: # Requires manual approval in Circle Ci
-          type: approval
+            - hold
       - publish-library:
           context: pdt-publish-restricted-context
           filters:


### PR DESCRIPTION
### What does this PR do?
Restricts approval access for circle ci workflows. Only members of the GitHub Team 'PDT' should be able to approve workflows for publishing.

### What issues does this PR fix or reference?
@W-8165486@