### PR TITLE
add query-results dir to gitignore

### DIFF
--- a/packages/templates/src/templates/project/gitignore
+++ b/packages/templates/src/templates/project/gitignore
@@ -12,6 +12,9 @@
 # LWC Jest coverage reports
 coverage/
 
+# SOQL Query Results
+**/scripts/soql/query-results
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
### What does this PR do?
This PR will add a new query-results directory to the .gitignore of the project template.
As part of the new soql query builder extension, customers will be able to save results from a soql query to the disk however we don't anticipate they will want to check in those results to source control by default.

### What issues does this PR fix or reference?
@W-8136966@