### PR TITLE
Bump @prettier/plugin-xml in /packages/templates/src/templates/projec…

### DIFF
--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -16,7 +16,7 @@
     "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\""
   },
   "devDependencies": {
-    "@prettier/plugin-xml": "^0.10.0",
+    "@prettier/plugin-xml": "^0.12.0",
     "@salesforce/eslint-config-lwc": "^0.7.0",
     "@salesforce/eslint-plugin-aura": "^1.4.0",
     "@salesforce/sfdx-lwc-jest": "^0.9.2",


### PR DESCRIPTION
…t (#212)

Bumps [@prettier/plugin-xml](https://github.com/prettier/plugin-xml) from 0.10.0 to 0.12.0.
- [Release notes](https://github.com/prettier/plugin-xml/releases)
- [Changelog](https://github.com/prettier/plugin-xml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/prettier/plugin-xml/compare/v0.10.0...v0.12.0)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

### What does this PR do?
Porting this PR that was not merged directly into main and was not merged back to the develop branch

### What issues does this PR fix or reference?
