### PR TITLE
chore: update npm release management orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.2.0
-  npm-release-management: salesforce/npm-release-management@2.0.0
+  npm-release-management: salesforce/npm-release-management@3.4.1
 
 parameters:
   fingerprint:
@@ -17,15 +17,32 @@ parameters:
     default: minor
 
 commands:
+  gh-config:
+    parameters:
+      cache_timeout:
+        description: 'Cache timeout in seconds'
+        type: integer
+        default: 120
+      gh_email:
+        description: 'GitHub email'
+        type: string
+        default: $GH_EMAIL
+      gh_username:
+        description: 'GitHub username'
+        type: string
+        default: 'Release Bot'
+    steps:
+      - run:
+          name: 'Configuring GitHub'
+          command: |
+            git config --global credential.helper 'cache --timeout=<< parameters.cache_timeout >>'
+            git config --global user.email "<< parameters.gh_email >>"
+            git config --global user.name "<< parameters.gh_username >>"
+
   setup-publish:
     description: 'Configure GitHub, Checkout, Install, Bump Package Version, Build'
     steps:
-      - run:
-          name: Configuring GitHub
-          command: |
-            git config --global credential.helper 'cache --timeout=120'
-            git config --global user.email "$GH_EMAIL"
-            git config --global user.name "Release Bot"
+      - gh-config
       - checkout
       - restore_cache:
           keys:
@@ -61,6 +78,19 @@ commands:
           fingerprints:
             - << pipeline.parameters.fingerprint >>
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+  create-git-tag:
+    steps:
+      - gh-config
+      - run:
+          name: Current git tags
+          command: git tag
+      - run:
+          name: Create new git tag
+          command: |
+            PKG_TAG="v$(cat package.json | jq -r .version)"
+            git tag -a $PKG_TAG -m "Releasing ${PKG_TAG}"
+            git push origin $PKG_TAG
 
 jobs:
   node-latest: &test
@@ -188,12 +218,14 @@ jobs:
           use_tarfile: true
       - npm-release-management/verify-signed-package
       - ssh-config
-      - npm-release-management/create-git-tag # this is looking up package.json
+      - create-git-tag # this is looking up package.json
       - run: git push origin main
 
 workflows:
-  version: 2
-  'salesforcedx-templates':
+  version: 2.1
+
+  commit-workflow:
+    unless: << pipeline.parameters.publish >>
     jobs:
       - node-latest
       - node-12


### PR DESCRIPTION
### What does this PR do?
1. Adds 'unless' clause for commit-workflow so we are not running multiple test jobs during publish.
2. Updates npm-release-management-orb version.
3. Adds new commands for gh-config and create-git-tag (this command was removed from the npm-release-management-orb).

### What issues does this PR fix or reference?
@W-8211855@