### PR TITLE
fix: publish library module without using orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/cli
-      - npm-release-management/publish:
-          use_tarfile: true
+      - run:
+          name: Set .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      -run:
+          name: Publish to NPM
+          command: |
+            RELEASE_VERSION="$(node -pe "require('./package.json').version")"
+            TARFILE=$(ls | grep $RELEASE_VERSION.tgz)
+            echo "publishing to npm using ${TARFILE}"
+            npm publish $TARFILE --access public
 
   publish-plugin:
     description: 'Publish plugin package'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
       - run:
           name: Set .npmrc
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      -run:
+      - run:
           name: Publish to NPM
           command: |
             RELEASE_VERSION="$(node -pe "require('./package.json').version")"

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ oclif.manifest.json
 
 # file generated for publishing
 *.tgz
+.npmrc


### PR DESCRIPTION
### What does this PR do?
Update CircleCI to publish the library package without using `npm-release-management` orb

### What issues does this PR fix or reference?
@W-8384687@