### PR TITLE
fix: revert back to using with sharing on Apex

### DIFF
--- a/packages/plugin-templates/test/commands/force/apex/class/create.test.ts
+++ b/packages/plugin-templates/test/commands/force/apex/class/create.test.ts
@@ -36,7 +36,7 @@ describe('Apex class creation tests:', () => {
           assert.file(['foo.cls', 'foo.cls-meta.xml']);
           assert.fileContent(
             path.join(process.cwd(), 'foo.cls'),
-            'public inherited sharing class foo'
+            'public with sharing class foo'
           );
         }
       );
@@ -104,7 +104,7 @@ describe('Apex class creation tests:', () => {
           ]);
           assert.fileContent(
             path.join('classes create', 'foo.cls'),
-            'public inherited sharing class foo'
+            'public with sharing class foo'
           );
         }
       );

--- a/packages/templates/src/templates/apexclass/DefaultApexClass.cls
+++ b/packages/templates/src/templates/apexclass/DefaultApexClass.cls
@@ -1,4 +1,4 @@
-public inherited sharing class <%= apiName %> {
+public with sharing class <%= apiName %> {
     public <%= apiName %>() {
 
     }

--- a/packages/templates/test/service/templateService.test.ts
+++ b/packages/templates/test/service/templateService.test.ts
@@ -48,7 +48,7 @@ describe('TemplateService', () => {
         'LibraryCreateClass.cls'
       );
       const expectedApexClassContent =
-        'public inherited sharing class LibraryCreateClass';
+        'public with sharing class LibraryCreateClass';
       const expectedApexClassMetaPath = path.join(
         'testsoutput',
         'libraryCreate',


### PR DESCRIPTION
### What does this PR do?
After discussing this internally we've decided to revert back to using `with sharing`

### What issues does this PR fix or reference?
@W-8926389@