### PR TITLE
fix: remove reference to query-results directory

### DIFF
--- a/packages/templates/src/templates/project/gitignore
+++ b/packages/templates/src/templates/project/gitignore
@@ -12,9 +12,6 @@
 # LWC Jest coverage reports
 coverage/
 
-# SOQL Query Results
-**/scripts/soql/query-results
-
 # Logs
 logs
 *.log


### PR DESCRIPTION
### What does this PR do?
The SOQL extension no longer creates a `query-results` directory for users when they save query data as csv or json.
So we dont need to include the directory in the `gitignore`

