### PR TITLE
feat: add project name to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ If you're interested in contributing, take a look at the [CONTRIBUTING](CONTRIBU
 
 If you're interested in building the plugin and library locally, take a look at the development [doc](contributing/developing.md).
 
-You can find more information about commands that the plugin provide in the [commands](COMMAND.md) doc.
+You can find more information about commands that the plugin provide in the [commands](COMMAND.md) doc

--- a/packages/plugin-templates/test/commands/project/create.test.ts
+++ b/packages/plugin-templates/test/commands/project/create.test.ts
@@ -70,6 +70,10 @@ describe('Project creation tests:', () => {
           path.join('foo', 'sfdx-project.json'),
           '"sfdcLoginUrl": "https://login.salesforce.com"'
         );
+        assert.fileContent(
+          path.join('foo', 'sfdx-project.json'),
+          '"name": "foo"'
+        );
 
         for (const file of vscodearray) {
           assert.file([path.join('foo', '.vscode', `${file}.json`)]);

--- a/packages/templates/src/generators/projectGenerator.ts
+++ b/packages/templates/src/generators/projectGenerator.ts
@@ -92,7 +92,8 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
         defaultpackagedir,
         namespace: ns,
         loginurl,
-        apiversion
+        apiversion,
+        name: projectname
       }
     );
 

--- a/packages/templates/src/templates/project/sfdx-project.json
+++ b/packages/templates/src/templates/project/sfdx-project.json
@@ -5,6 +5,7 @@
       "default": true
     }
   ],
+  "name": "<%= name %>",
   "namespace": "<%= namespace %>",
   "sfdcLoginUrl": "<%= loginurl %>",
   "sourceApiVersion": "<%= apiversion %>"


### PR DESCRIPTION
### What does this PR do?

Adds a `name` field to sfdx-project.json for use by the new Functions product

### What issues does this PR fix or reference?

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000009lOcYAI/view
