### PR TITLE
chore: upgrade yarn.lock dependency for schemas

### DIFF
--- a/packages/plugin-templates/yarn.lock
+++ b/packages/plugin-templates/yarn.lock
@@ -458,9 +458,9 @@
     tslib "^1"
 
 "@salesforce/schemas@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.0.1.tgz#d1db56759d2b22a7688e1821aec564e979237ad2"
-  integrity sha512-78pP1GB/DbIS8nSWGL0GpQ27g02drrEo0vzYdRipGYAIXHMzlh1gqEsq0pOiIQlPm1MxWyEqbmf4GG5qSVsd0Q==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
+  integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
 "@salesforce/ts-sinon@^1.2.2":
   version "1.2.2"

--- a/packages/templates/yarn.lock
+++ b/packages/templates/yarn.lock
@@ -245,9 +245,9 @@
     tslib "^1.10.0"
 
 "@salesforce/schemas@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.0.1.tgz#d1db56759d2b22a7688e1821aec564e979237ad2"
-  integrity sha512-78pP1GB/DbIS8nSWGL0GpQ27g02drrEo0vzYdRipGYAIXHMzlh1gqEsq0pOiIQlPm1MxWyEqbmf4GG5qSVsd0Q==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
+  integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
 "@salesforce/ts-types@^1.0.0":
   version "1.4.2"


### PR DESCRIPTION
### What does this PR do?
Upgrades schema dependency to 1.1.0. This is necessary to bring in change https://github.com/forcedotcom/schemas/pull/35, which is needed for #296.
