### PR TITLE
chore: updated version 51.4.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "version": "51.3.1",
+  "version": "51.4.0",
   "npmClient": "yarn",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/plugin-templates/package.json
+++ b/packages/plugin-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-templates",
-  "version": "51.3.1",
+  "version": "51.4.0",
   "main": "index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
@@ -10,7 +10,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2.2.0",
     "@salesforce/core": "2.13.0",
-    "@salesforce/templates": "51.3.1",
+    "@salesforce/templates": "51.4.0",
     "tslib": "^1",
     "yeoman-environment": "2.4.0",
     "yeoman-generator": "4.0.1"

--- a/packages/plugin-templates/yarn.lock
+++ b/packages/plugin-templates/yarn.lock
@@ -469,17 +469,6 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.0.tgz#bbf94a11ee036f2b0ec6ba82306cd9565a6ba26b"
   integrity sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg==
 
-"@salesforce/templates@51.3.0":
-  version "51.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-51.3.0.tgz#f31cf9f9abd98e1cd425048248429fda2dc235a7"
-  integrity sha512-GvoqafreK76kE1nEmrVvrPsYXxxqFw7fVBLB+02ZHfOccUGVHUrPAMjN21TVwcuyWvFqevZUtceypDFs50RVHg==
-  dependencies:
-    "@salesforce/core" "2.13.0"
-    mime-types "^2.1.27"
-    tslib "^1"
-    yeoman-environment "2.4.0"
-    yeoman-generator "4.0.1"
-
 "@salesforce/ts-sinon@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.2.2.tgz#4d99437def324f9e5507a02c3b322a40ed769167"
@@ -3459,7 +3448,7 @@ mime-db@1.47.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
   integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.30"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
   integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/templates",
-  "version": "51.3.1",
+  "version": "51.4.0",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "main": "lib/index.js",


### PR DESCRIPTION
### What does this PR do?
manually bump main version to 51.4.0
https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-templates/953/workflows/ca0e8422-e6f8-465b-a9fe-86d758fc34b0/jobs/3534/parallel-runs/0/steps/0-116
`sfdx-trust plugins:trust:verify --npm $PKG_NAME@$PKG_VERSION --json` failed with `NpmTagNotFound`. might be occasional
