### PR TITLE
chore: updated version 51.5.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "51.4.0",
+  "version": "51.5.0",
   "npmClient": "yarn",
   "packages": ["packages/*"]
 }

--- a/packages/plugin-templates/package.json
+++ b/packages/plugin-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-templates",
-  "version": "51.4.0",
+  "version": "51.5.0",
   "main": "index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
@@ -10,7 +10,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2.2.0",
     "@salesforce/core": "2.23.2",
-    "@salesforce/templates": "51.4.0",
+    "@salesforce/templates": "51.5.0",
     "tslib": "^1",
     "yeoman-environment": "2.4.0",
     "yeoman-generator": "4.0.1"

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/templates",
-  "version": "51.4.0",
+  "version": "51.5.0",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "main": "lib/index.js",


### PR DESCRIPTION
"The dist tag was not found" error (W-9357574) blocked the version bump step in CI.

Manually bump main version.