### PR TITLE
Simplified linting scripts and reduced dependencies

### DIFF
--- a/packages/templates/src/templates/project/aura.eslintrc.json
+++ b/packages/templates/src/templates/project/aura.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "plugins": ["@salesforce/eslint-plugin-aura"],
-  "extends": ["plugin:@salesforce/eslint-plugin-aura/recommended", "prettier"],
+  "extends": ["plugin:@salesforce/eslint-plugin-aura/recommended"],
   "rules": {
     "vars-on-top": "off",
     "no-unused-expressions": "off"

--- a/packages/templates/src/templates/project/lwc.eslintrc.json
+++ b/packages/templates/src/templates/project/lwc.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@salesforce/eslint-config-lwc/recommended", "prettier"],
+  "extends": ["@salesforce/eslint-config-lwc/recommended"],
   "overrides": [
     {
       "files": ["*.test.js"],

--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -17,18 +17,18 @@
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^1.0.1",
-    "@prettier/plugin-xml": "^0.13.1",
-    "@salesforce/eslint-config-lwc": "^2.0.0",
+    "@prettier/plugin-xml": "^1.0.2",
+    "@salesforce/eslint-config-lwc": "^2.1.1",
     "@salesforce/eslint-plugin-aura": "^2.0.0",
     "@salesforce/eslint-plugin-lightning": "^0.1.1",
-    "@salesforce/sfdx-lwc-jest": "^0.13.0",
-    "eslint": "^7.29.0",
+    "@salesforce/sfdx-lwc-jest": "^0.12.6",
+    "eslint": "^7.31.0",
     "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jest": "^24.3.6",
-    "husky": "^7.0.0",
-    "lint-staged": "^11.0.0",
+    "eslint-plugin-jest": "^24.4.0",
+    "husky": "^7.0.1",
+    "lint-staged": "^11.1.1",
     "prettier": "^2.3.2",
-    "prettier-plugin-apex": "^1.10.1"
+    "prettier-plugin-apex": "^1.10.0"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [

--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -4,9 +4,7 @@
   "version": "1.0.0",
   "description": "Salesforce App",
   "scripts": {
-    "lint": "npm run lint:lwc && npm run lint:aura",
-    "lint:aura": "eslint **/aura/**",
-    "lint:lwc": "eslint **/lwc/**",
+    "lint": "eslint **/{aura,lwc}/**",
     "test": "npm run test:unit",
     "test:unit": "sfdx-lwc-jest",
     "test:unit:watch": "sfdx-lwc-jest --watch",
@@ -25,13 +23,12 @@
     "@salesforce/eslint-plugin-lightning": "^0.1.1",
     "@salesforce/sfdx-lwc-jest": "^0.13.0",
     "eslint": "^7.29.0",
-    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^24.3.6",
-    "husky": "^6.0.0",
+    "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
-    "prettier": "^2.3.1",
-    "prettier-plugin-apex": "^1.9.1"
+    "prettier": "^2.3.2",
+    "prettier-plugin-apex": "^1.10.1"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
Following feedback from @pmdartus, this PR on the project template
- Merges the two linting scripts (Aura and LWC) into a single one
- Gets rid of `eslint-config-prettier` because it is not needed