### PR TITLE
fix: add default masterLabel to analytics lwcs

### DIFF
--- a/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
+++ b/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
@@ -234,6 +234,7 @@ describe('Lightning component creation tests:', () => {
           assert.file(metaFile);
           assert.file(path.join('lwc', 'foo', 'foo.html'));
           assert.file(jsFile);
+          assert.fileContent(metaFile, '<masterLabel>Foo</masterLabel>');
           assert.fileContent(metaFile, '<target>analytics__Dashboard</target>');
           assert.fileContent(metaFile, 'targets="analytics__Dashboard"');
           assert.fileContent(metaFile, '<hasStep>false</hasStep>');
@@ -252,7 +253,7 @@ describe('Lightning component creation tests:', () => {
       .command([
         'force:lightning:component:create',
         '--componentname',
-        'foo',
+        'fooWithStep',
         '--outputdir',
         'lwc',
         '--type',
@@ -263,17 +264,18 @@ describe('Lightning component creation tests:', () => {
       .it(
         'should create analyticsDashboardWithStep lwc files in the lwc output directory',
         ctx => {
-          const jsFile = path.join('lwc', 'foo', 'foo.js');
-          const metaFile = path.join('lwc', 'foo', 'foo.js-meta.xml');
+          const jsFile = path.join('lwc', 'fooWithStep', 'fooWithStep.js');
+          const metaFile = path.join('lwc', 'fooWithStep', 'fooWithStep.js-meta.xml');
           assert.file(metaFile);
-          assert.file(path.join('lwc', 'foo', 'foo.html'));
+          assert.file(path.join('lwc', 'fooWithStep', 'fooWithStep.html'));
           assert.file(jsFile);
+          assert.fileContent(metaFile, '<masterLabel>Foo With Step</masterLabel>');
           assert.fileContent(metaFile, '<target>analytics__Dashboard</target>');
           assert.fileContent(metaFile, 'targets="analytics__Dashboard"');
           assert.fileContent(metaFile, '<hasStep>true</hasStep>');
           assert.fileContent(
             jsFile,
-            'export default class Foo extends LightningElement {'
+            'export default class FooWithStep extends LightningElement {'
           );
           assert.fileContent(jsFile, '@api getState;');
           assert.fileContent(jsFile, '@api setState;');

--- a/packages/templates/src/generators/lightningComponentGenerator.ts
+++ b/packages/templates/src/generators/lightningComponentGenerator.ts
@@ -4,6 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import { camelCaseToTitleCase } from '@salesforce/kit';
 import * as path from 'path';
 import { nls } from '../i18n';
 import { CreateUtil } from '../utils';
@@ -170,12 +172,13 @@ export default class LightningComponentGenerator extends SfdxGenerator<
         {}
       );
       if (!internal) {
+        const masterLabel = camelCaseToTitleCase(componentname).replace(/</g, '&lt;').replace(/>/g, '&gt;');
         this.fs.copyTpl(
           this.templatePath(`${template}.js-meta.xml`),
           this.destinationPath(
             path.join(outputdir, fileName, `${fileName}.js-meta.xml`)
           ),
-          { apiVersion: apiversion }
+          { apiVersion: apiversion, masterLabel }
         );
       }
     }

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js-meta.xml
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js-meta.xml
@@ -2,6 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion><%= apiVersion %></apiVersion>
     <isExposed>true</isExposed>
+    <masterLabel><%= masterLabel %></masterLabel>
     <targets>
         <target>analytics__Dashboard</target>
     </targets>

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js-meta.xml
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js-meta.xml
@@ -2,6 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion><%= apiVersion %></apiVersion>
     <isExposed>true</isExposed>
+    <masterLabel><%= masterLabel %></masterLabel>
     <targets>
         <target>analytics__Dashboard</target>
     </targets>


### PR DESCRIPTION
### What does this PR do?

Set the `<masterLabel>` in the .js-meta.xml for analytics dashboard lwcs, defaulting to a title case of the file name (e.g. fooWithStep -> Foo With Step).

### What issues does this PR fix or reference?
@W-9889592@

cc: @jimmydief