### PR TITLE
feat: add .sf/ and deploy-options.json to project .gitignore

### DIFF
--- a/packages/templates/src/templates/project/gitignore
+++ b/packages/templates/src/templates/project/gitignore
@@ -3,8 +3,10 @@
 # For useful gitignore templates see: https://github.com/github/gitignore
 
 # Salesforce cache
+.sf/
 .sfdx/
 .localdevserver/
+deploy-options.json
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json


### PR DESCRIPTION
### What does this PR do?
Adds `.sf/` and `deploy-options.json` to the `.gitignore` that will be generated by `sf generate project`.

[The `name` property in `sfdx-project.json` was already added by @cafreeman](https://github.com/forcedotcom/salesforcedx-templates/blame/develop/packages/templates/src/templates/project/sfdx-project.json#L8).

### What issues does this PR fix or reference?
@W-9789875@