### PR TITLE
feat: added node env to ESLint config for LWC tests

### DIFF
--- a/packages/templates/src/templates/project/lwc.eslintrc.json
+++ b/packages/templates/src/templates/project/lwc.eslintrc.json
@@ -5,6 +5,9 @@
       "files": ["*.test.js"],
       "rules": {
         "@lwc/lwc/no-unexpected-wire-adapter-usages": "off"
+      },
+      "env": {
+        "node": true
       }
     }
   ]


### PR DESCRIPTION
This PR adds the `node` environment to the ESLint configuration for LWC test files.

This configuration helps us ignore false positive errors when ESLint reports undefined variables for Node.js global variables such as `process` or `setImmediate`:

![Screen Shot 2021-10-08 at 15 30 32](https://user-images.githubusercontent.com/5071767/136566505-e2fd7aca-c567-4b68-b94a-a8a4a80aef27.png)

