### PR TITLE
fix: decrement prettier-plugin-apex template version requirement

### DIFF
--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -28,7 +28,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.2",
-    "prettier-plugin-apex": "^1.10.1"
+    "prettier-plugin-apex": "^1.10.0"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
### What does this PR do?

The template dev dependency prettier-plugin-apex has a version requirement that is higher than the
current publically released version. This was causing build issues when using the template. This fix
decrements that version requirement so that it is inline with the publically available version.

### What issues does this PR fix or reference?

fix #394
