### PR TITLE
chore: bump version to 53

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "52.6.0",
+  "version": "53.6.0",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "53.6.0",
+  "version": "53.0.0",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/plugin-templates/package.json
+++ b/packages/plugin-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-templates",
-  "version": "53.6.0",
+  "version": "53.0.0",
   "main": "index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
@@ -10,7 +10,7 @@
     "@oclif/errors": "^1",
     "@salesforce/command": "^2.2.0",
     "@salesforce/core": "2.32.0",
-    "@salesforce/templates": "52.7.0",
+    "@salesforce/templates": "53.0.0",
     "tslib": "^1",
     "yeoman-environment": "2.4.0",
     "yeoman-generator": "4.0.1"

--- a/packages/plugin-templates/package.json
+++ b/packages/plugin-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-templates",
-  "version": "52.6.0",
+  "version": "53.6.0",
   "main": "index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/templates",
-  "version": "53.6.0",
+  "version": "53.0.0",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "main": "lib/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/templates",
-  "version": "52.6.0",
+  "version": "53.6.0",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "main": "lib/index.js",

--- a/packages/templates/test/generators/sfdxGenerator.test.ts
+++ b/packages/templates/test/generators/sfdxGenerator.test.ts
@@ -37,7 +37,7 @@ describe('SfdxGenerator', () => {
     assert.calledWith(
       doWritingStub,
       match({
-        apiversion: '52.0',
+        apiversion: '53.0',
         outputdir: process.cwd()
       })
     );


### PR DESCRIPTION
### What does this PR do?
Bump `pjson` version so that templates are created using `sourceApiVersion` equal to `53`
### What issues does this PR fix or reference?
@W-10169202@