### PR TITLE
Fix for "No matching version found for prettier-plugin-apex@^1.10.1" on npm install

### DIFF
--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -28,7 +28,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.2",
-    "prettier-plugin-apex": "^1.10.1"
+    "prettier-plugin-apex": "^1.10.0"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
After creating a project using `sfdx force:project --projectname=newproject`, this error message appears on `npm install` in the project folder:
```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for prettier-plugin-apex@^1.10.1.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/benjaminloerincz/.npm/_logs/2021-12-23T14_17_36_183Z-debug-0.log
```

### What does this PR do?

This PR changes the version number for prettier-plugin-apex.

### What issues does this PR fix or reference?

- [394](https://github.com/forcedotcom/salesforcedx-templates/issues/394)
- [398](https://github.com/forcedotcom/salesforcedx-templates/issues/398)