### PR TITLE
Downgrade prettier-plugin-apex to a correct latest version

### DIFF
--- a/packages/templates/src/templates/project/package.json
+++ b/packages/templates/src/templates/project/package.json
@@ -28,7 +28,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.2",
-    "prettier-plugin-apex": "^1.10.1"
+    "prettier-plugin-apex": "^1.10.0"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
### What does this PR do?

Fix the template to generate the correct latest version of [prettier-plugin-apex](https://www.npmjs.com/package/prettier-plugin-apex) plugin. 

Unfortunately this fix before from [@quinnmcphail](https://github.com/quinnmcphail) was reverted. Please refer [this comment](https://github.com/forcedotcom/salesforcedx-templates/issues/394#issuecomment-947102474) for more details and feel free to close this PR if its unnecessary. 

### What issues does this PR fix or reference?

Fix #394 #398 https://github.com/forcedotcom/cli/issues/1334