### PR TITLE
fix: add refresh api hook to dashboard lwcs

### DIFF
--- a/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
+++ b/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
@@ -244,6 +244,7 @@ describe('Lightning component creation tests:', () => {
           );
           assert.fileContent(jsFile, '@api getState;');
           assert.fileContent(jsFile, '@api setState;');
+          assert.fileContent(jsFile, '@api refresh;');
         }
       );
     test
@@ -286,6 +287,7 @@ describe('Lightning component creation tests:', () => {
           );
           assert.fileContent(jsFile, '@api getState;');
           assert.fileContent(jsFile, '@api setState;');
+          assert.fileContent(jsFile, '@api refresh;');
           assert.fileContent(jsFile, '@api results;');
           assert.fileContent(jsFile, '@api metadata;');
           assert.fileContent(jsFile, '@api selection;');

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js
@@ -3,4 +3,5 @@ import { LightningElement, api } from 'lwc';
 export default class <%= className %> extends LightningElement {
   @api getState;
   @api setState;
+  @api refresh;
 }

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js
@@ -8,4 +8,5 @@ export default class <%= className %> extends LightningElement {
   @api selectMode;
   @api getState;
   @api setState;
+  @api refresh;
 }


### PR DESCRIPTION
This was added to the server api in Spring '22 (54.0), just updating the lwc template to include it.
