### PR TITLE
fix: add `stateChangedCallback()` to dashboard lwcs

### DIFF
--- a/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
+++ b/packages/plugin-templates/test/commands/force/lightning/component/create.test.ts
@@ -245,6 +245,10 @@ describe('Lightning component creation tests:', () => {
           assert.fileContent(jsFile, '@api getState;');
           assert.fileContent(jsFile, '@api setState;');
           assert.fileContent(jsFile, '@api refresh;');
+          assert.fileContent(
+            jsFile,
+            '@api stateChangedCallback(prevState, newState)'
+          );
         }
       );
     test
@@ -293,6 +297,10 @@ describe('Lightning component creation tests:', () => {
           assert.fileContent(jsFile, '@api selection;');
           assert.fileContent(jsFile, '@api setSelection;');
           assert.fileContent(jsFile, '@api selectMode;');
+          assert.fileContent(
+            jsFile,
+            '@api stateChangedCallback(prevState, newState)'
+          );
         }
       );
   });

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboard/analyticsDashboard.js
@@ -4,4 +4,6 @@ export default class <%= className %> extends LightningElement {
   @api getState;
   @api setState;
   @api refresh;
+
+  @api stateChangedCallback(prevState, newState) {}
 }

--- a/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js
+++ b/packages/templates/src/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js
@@ -9,4 +9,6 @@ export default class <%= className %> extends LightningElement {
   @api getState;
   @api setState;
   @api refresh;
+
+  @api stateChangedCallback(prevState, newState) {}
 }


### PR DESCRIPTION
### What does this PR do?
Adds `stateChangedCallback()` to dashboard lwcs. It's new in Summer '22

### What issues does this PR fix or reference?
@W-11111405@