### PR TITLE
chore: export CreateUtil

### DIFF
--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -8,3 +8,4 @@
 import { TemplateService } from './service/templateService';
 export { TemplateService };
 export * from './utils/types';
+export * from './utils/createUtil';


### PR DESCRIPTION
### What does this PR do?
"SFDX: Create Lightning Web Component" is using CreateUtil to ensure new component names following the lightning component naming rules. This PR exports CreateUtil so other commands like "SFDX: Rename Component" can also leverage the functions for guarding user input for a new component name. 

### What issues does this PR fix or reference?
[#4145](https://github.com/forcedotcom/salesforcedx-vscode/pull/4145)