### PR TITLE
chore: remove listing git tags so publish will not fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,6 @@ commands:
     steps:
       - gh-config
       - run:
-          name: Current git tags
-          command: git tag
-      - run:
           name: Create new git tag
           command: |
             PKG_TAG="v$(cat package.json | jq -r .version)"


### PR DESCRIPTION
### What does this PR do?
Removes the unnecessary listing of the git tags so that auto publish jobs will complete. 

### What issues does this PR fix or reference?
Found when publish was attempted: https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-templates/1589/workflows/1600396c-c065-4125-8c7a-28cf09f1ad31/jobs/6155