### PR TITLE
refactor: change the location of the default api version

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -31,7 +31,7 @@
     "type:feedback": "",
     "type:duplicate": ""
   },
-  "defaultBuild": "offcore.tooling.48",
+  "defaultBuild": "offcore.tooling.56",
   "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED"
 }

--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -1,0 +1,36 @@
+name: manual release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
+        # overriding some of the basic behaviors to just get the changelog
+        with:
+          git-user-name: Release Bot
+          git-user-email: ${{ secrets.IDEE_GH_EMAIL }}
+          github-token: ${{ secrets.IDEE_GH_TOKEN }}
+          output-file: false
+          # always do the release, even if there are no semantic commits
+          skip-on-empty: false
+          tag-prefix: ''
+      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+        id: packageVersion
+        with:
+          path: 'package.json'
+          prop_path: 'version'
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+        with:
+          tag_name: ${{ steps.packageVersion.outputs.prop }}
+          release_name: ${{ steps.packageVersion.outputs.prop }}

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -2,7 +2,7 @@
 
 This is a guide for publishing Templates to npm. Most contributors don't need to worry about publishing. Publishing can only be done by the Salesforce tooling team. Please contact us if there are changes that you'd like to publish.
 
-Every PR merge to main gets published automatically and goes through a minor version upgrade. The following steps are only when you need a one-off release to either pubish a major version or a patch version.
+Every PR merge to main gets published automatically and follows semantic versioning. The following steps are only when you need a manual release.
 
 ## Prerequisites
 
@@ -16,13 +16,15 @@ The salesforcedx-templates project uses a two-branch strategy. Work that is curr
 
 ## Publishing to NPM
 
-When a commit is merged to main, we will automatically create the github release, and then publish the changes to npm using our Github Actions.
+When a commit is merged to main, we will automatically create the github release, and then publish the changes to npm using our Github Actions. If that fails for any reason and you need to create a manual release, you can do so using the following workflow.
 
-### Publish a major or patch release version manually
+### Publish a release version manually
 
 1. Navigate to the `Actions` tab in the repository
-1. Under `Workflows` on the left side, select `Publish`.
-1. Select `Run Workflow` on the top row.
-1. Enter the desired version number, following semantic versioning.
+1. Under `Workflows` on the left side, select `manual release`.
 1. Select `Run Workflow`, and ensure the newest version is published to npm once the workflow completes.
 1. Any failures will notify the pdt release channel internally.
+
+### Major version notes
+
+Historically, the package version of the library has supplied the Salesforce API version to be used for creating the most up-to-date metadata for Salesforce components. This meant that we were not able to use semantic versioning to indicate a major, or breaking, change. The current version of the templates library is now configured so that the `salesforceApiVersion` field in the `package.json` will now indicate the version to use for Salesforce metadata.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@salesforce/templates",
   "version": "56.0.0",
+  "salesforceApiVersion": "56",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",
   "main": "lib/index.js",

--- a/src/service/templateService.ts
+++ b/src/service/templateService.ts
@@ -64,7 +64,7 @@ export class TemplateService {
    */
   public static getDefaultApiVersion(): string {
     const packageJsonPath = path.join('..', '..', 'package.json');
-    const versionTrimmed = require(packageJsonPath).version.trim();
+    const versionTrimmed = require(packageJsonPath).salesforceApiVersion.trim();
     return `${versionTrimmed.split('.')[0]}.0`;
   }
 

--- a/test/generators/sfdxGenerator.test.ts
+++ b/test/generators/sfdxGenerator.test.ts
@@ -13,7 +13,7 @@ import { TemplateService } from '../../src/service/templateService';
 import * as YeomanEnvironment from 'yeoman-environment';
 
 describe('SfdxGenerator', () => {
-  const API_VERSION = '56.0';
+  const API_VERSION_STUB = '50';
   interface MyTemplateOptions extends TemplateOptions {
     // env and resolved are for testing (similar to how yeoman environment instantiates the generators)
     env: YeomanEnvironment;
@@ -40,13 +40,13 @@ describe('SfdxGenerator', () => {
     const getDefaultApiVersionStub = stub(
       TemplateService,
       'getDefaultApiVersion'
-    ).returns(API_VERSION);
+    ).returns(API_VERSION_STUB);
     const generator = new MyGenerator([], mockMyGeneratorOptions);
     generator.writing();
     assert.calledWith(
       doWritingStub,
       match({
-        apiversion: API_VERSION,
+        apiversion: API_VERSION_STUB,
         outputdir: process.cwd(),
       })
     );


### PR DESCRIPTION
### What does this PR do?
Changes where we derive the default Salesforce API version. Previously we were conflating the version of the package with the Salesforce API version, so we could not benefit from semantic versioning. In order to keep our CI simple and benefit from semantic versioning, this will separate these two values. 

Going forward with the code as it is here, the only value that will need to change during major Salesforce version updates is the `salesforceApiVersion` in the `package.json`. The version should no longer be directly touched, as the `conventional-changelog` will update this as needed. 

A better longer term solution would be to dynamically generate this value, but this would require some understanding of what "default" should mean.

This PR also updates the `publishing.md` documentation to note this change and how publishing now works, and adds a manual release workflow to support the one-off publishing supported in other repos.

### What issues does this PR fix or reference?
Follow-up to #527 