### PR TITLE
feat: add Python Functions entries to the template `.gitignore`

### DIFF
--- a/src/templates/project/gitignore
+++ b/src/templates/project/gitignore
@@ -38,3 +38,8 @@ $RECYCLE.BIN/
 
 # Local environment variables
 .env
+
+# Python Salesforce Functions
+**/__pycache__/
+**/.venv/
+**/venv/


### PR DESCRIPTION
Python support for Salesforce Functions is currently in beta:
https://github.com/heroku/sf-functions-python#readme

When working on a Python project, it's typical to install the project's dependencies inside a Python "virtual environment". This environment is typically placed inside the project directory, with a directory name of `.venv` or `venv`. This environment is machine-specific, so must not be committed to source control.

In addition, when Python files are run, the Python interpreter writes the generated bytecode to disk, as a performance improvement for subsequent invocations. This bytecode is stored under `__pycache__` directories alongside the source code, and is environment-specific so similarly should not be committed to source control.

Currently the beta docs for Python Functions have the user manually edit their project's `.gitignore`, however this adds friction and a potential source of mistakes, so we should add these entries to the template directly.

[@W-12198175@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001GxXKrYAN/view).