### PR TITLE
Sm/fixes

### DIFF
--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -15,7 +15,6 @@ jobs:
         run: git config --global core.autocrlf false
         shell: bash
       - uses: actions/checkout@v3
-      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@main
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "mime-types": "^2.1.27",
     "proxy-agent": "^5.0.0",
     "proxy-from-env": "^1.1.0",
-    "shelljs": "^0.8.5",
-    "tar": "^6.1.10",
+    "tar": "^6.1.13",
     "tslib": "^1",
     "yeoman-environment": "^3.9.1",
     "yeoman-generator": "^5.6.1"
@@ -59,6 +58,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.0.5",
     "pretty-quick": "^3.1.0",
+    "shelljs": "^0.8.5",
     "shx": "^0.3.4",
     "sinon": "10.0.0",
     "ts-node": "^10.0.0",

--- a/src/generators/analyticsTemplateGenerator.ts
+++ b/src/generators/analyticsTemplateGenerator.ts
@@ -19,14 +19,14 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
   public validateOptions(): void {
     CreateUtil.checkInputs(this.options.templatename);
 
-    const fileparts = path.resolve(this.options.outputdir).split(path.sep);
+    const fileparts = path.resolve(this.outputdir).split(path.sep);
     if (!fileparts.includes('waveTemplates')) {
       throw new Error(nls.localize('MissingWaveTemplatesDir'));
     }
   }
 
   public writing(): void {
-    const { outputdir, templatename, apiversion } = this.options;
+    const { templatename } = this.options;
     // tslint:disable-next-line:no-unused-expression
     this.fs.copyTpl(
       this.templatePath(
@@ -38,7 +38,7 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
       ),
       this.destinationPath(
         path.join(
-          outputdir,
+          this.outputdir,
           templatename,
           'dashboards',
           templatename + 'Dashboard.json'
@@ -51,13 +51,15 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
         path.join('DefaultAnalyticsTemplate', 'app-to-template-rules.json')
       ),
       this.destinationPath(
-        path.join(outputdir, templatename, 'app-to-template-rules.json')
+        path.join(this.outputdir, templatename, 'app-to-template-rules.json')
       ),
       {}
     );
     this.fs.copyTpl(
       this.templatePath(path.join('DefaultAnalyticsTemplate', 'folder.json')),
-      this.destinationPath(path.join(outputdir, templatename, 'folder.json')),
+      this.destinationPath(
+        path.join(this.outputdir, templatename, 'folder.json')
+      ),
       { templateName: templatename }
     );
     this.fs.copyTpl(
@@ -65,7 +67,7 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
         path.join('DefaultAnalyticsTemplate', 'releaseNotes.html')
       ),
       this.destinationPath(
-        path.join(outputdir, templatename, 'releaseNotes.html')
+        path.join(this.outputdir, templatename, 'releaseNotes.html')
       ),
       {}
     );
@@ -74,11 +76,11 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
         path.join('DefaultAnalyticsTemplate', 'template-info.json')
       ),
       this.destinationPath(
-        path.join(outputdir, templatename, 'template-info.json')
+        path.join(this.outputdir, templatename, 'template-info.json')
       ),
       {
         templateName: templatename,
-        sourceApiVersion: apiversion,
+        sourceApiVersion: this.apiversion,
       }
     );
     this.fs.copyTpl(
@@ -86,13 +88,13 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
         path.join('DefaultAnalyticsTemplate', 'template-to-app-rules.json')
       ),
       this.destinationPath(
-        path.join(outputdir, templatename, 'template-to-app-rules.json')
+        path.join(this.outputdir, templatename, 'template-to-app-rules.json')
       ),
       {}
     );
     this.fs.copyTpl(
       this.templatePath(path.join('DefaultAnalyticsTemplate', 'ui.json')),
-      this.destinationPath(path.join(outputdir, templatename, 'ui.json')),
+      this.destinationPath(path.join(this.outputdir, templatename, 'ui.json')),
       {}
     );
     this.fs.copyTpl(
@@ -100,7 +102,7 @@ export default class AnalyticsTemplateGenerator extends SfdxGenerator<AnalyticsT
         path.join('DefaultAnalyticsTemplate', 'variables.json')
       ),
       this.destinationPath(
-        path.join(outputdir, templatename, 'variables.json')
+        path.join(this.outputdir, templatename, 'variables.json')
       ),
       {}
     );

--- a/src/generators/apexClassGenerator.ts
+++ b/src/generators/apexClassGenerator.ts
@@ -21,16 +21,18 @@ export default class ApexClassGenerator extends SfdxGenerator<ApexClassOptions> 
   }
 
   public writing(): void {
-    const { template, outputdir, classname, apiversion } = this.options;
+    const { template, classname } = this.options;
     this.fs.copyTpl(
       this.templatePath(`${template}.cls`),
-      this.destinationPath(path.join(outputdir, `${classname}.cls`)),
+      this.destinationPath(path.join(this.outputdir, `${classname}.cls`)),
       { apiName: classname }
     ),
       this.fs.copyTpl(
         this.templatePath('_class.cls-meta.xml'),
-        this.destinationPath(path.join(outputdir, `${classname}.cls-meta.xml`)),
-        { apiName: classname, apiVersion: apiversion }
+        this.destinationPath(
+          path.join(this.outputdir, `${classname}.cls-meta.xml`)
+        ),
+        { apiName: classname, apiVersion: this.apiversion }
       );
   }
 }

--- a/src/generators/apexTriggerGenerator.ts
+++ b/src/generators/apexTriggerGenerator.ts
@@ -19,25 +19,18 @@ export default class ApexTriggerGenerator extends SfdxGenerator<ApexTriggerOptio
     CreateUtil.checkInputs(this.options.template);
   }
   public writing(): void {
-    const {
-      template,
-      outputdir,
-      triggername,
-      apiversion,
-      triggerevents,
-      sobject,
-    } = this.options;
+    const { template, triggername, triggerevents, sobject } = this.options;
     this.fs.copyTpl(
       this.templatePath(`${template}.trigger`),
-      this.destinationPath(path.join(outputdir, `${triggername}.trigger`)),
+      this.destinationPath(path.join(this.outputdir, `${triggername}.trigger`)),
       { triggername, sobject, triggerEvents: triggerevents }
     ),
       this.fs.copyTpl(
         this.templatePath('_trigger.trigger-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, `${triggername}.trigger-meta.xml`)
+          path.join(this.outputdir, `${triggername}.trigger-meta.xml`)
         ),
-        { apiVersion: apiversion }
+        { apiVersion: this.apiversion }
       );
   }
 }

--- a/src/generators/apexTriggerGenerator.ts
+++ b/src/generators/apexTriggerGenerator.ts
@@ -24,13 +24,13 @@ export default class ApexTriggerGenerator extends SfdxGenerator<ApexTriggerOptio
       this.templatePath(`${template}.trigger`),
       this.destinationPath(path.join(this.outputdir, `${triggername}.trigger`)),
       { triggername, sobject, triggerEvents: triggerevents }
-    ),
-      this.fs.copyTpl(
-        this.templatePath('_trigger.trigger-meta.xml'),
-        this.destinationPath(
-          path.join(this.outputdir, `${triggername}.trigger-meta.xml`)
-        ),
-        { apiVersion: this.apiversion }
-      );
+    );
+    this.fs.copyTpl(
+      this.templatePath('_trigger.trigger-meta.xml'),
+      this.destinationPath(
+        path.join(this.outputdir, `${triggername}.trigger-meta.xml`)
+      ),
+      { apiVersion: this.apiversion }
+    );
   }
 }

--- a/src/generators/lightningAppGenerator.ts
+++ b/src/generators/lightningAppGenerator.ts
@@ -20,68 +20,74 @@ export default class LightningAppGenerator extends SfdxGenerator<LightningAppOpt
     CreateUtil.checkInputs(this.options.appname);
     CreateUtil.checkInputs(this.options.template);
 
-    const fileparts = path.resolve(this.options.outputdir).split(path.sep);
+    const fileparts = path.resolve(this.outputdir).split(path.sep);
     if (!fileparts.includes('aura') && !this.options.internal) {
       throw new Error(nls.localize('MissingAuraDir'));
     }
   }
 
   public writing(): void {
-    const { template, outputdir, appname, apiversion, internal } = this.options;
+    const { template, appname, internal } = this.options;
     // tslint:disable-next-line:no-unused-expression
     if (!internal) {
       this.fs.copyTpl(
         this.templatePath('_auradefinitionbundle.app-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, appname, `${appname}.app-meta.xml`)
+          path.join(this.outputdir, appname, `${appname}.app-meta.xml`)
         ),
         {
-          apiVersion: apiversion,
+          apiVersion: this.apiversion,
           description: nls.localize('LightningAppBundle'),
         }
       );
     }
     this.fs.copyTpl(
       this.templatePath(`${template}.app`),
-      this.destinationPath(path.join(outputdir, appname, `${appname}.app`)),
+      this.destinationPath(
+        path.join(this.outputdir, appname, `${appname}.app`)
+      ),
       {}
     ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningAuradoc.auradoc'),
         this.destinationPath(
-          path.join(outputdir, appname, `${appname}.auradoc`)
+          path.join(this.outputdir, appname, `${appname}.auradoc`)
         ),
         {}
       ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningController.js'),
         this.destinationPath(
-          path.join(outputdir, appname, `${appname}Controller.js`)
+          path.join(this.outputdir, appname, `${appname}Controller.js`)
         ),
         {}
       ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningCss.css'),
-        this.destinationPath(path.join(outputdir, appname, `${appname}.css`)),
+        this.destinationPath(
+          path.join(this.outputdir, appname, `${appname}.css`)
+        ),
         {}
       ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningHelper.js'),
         this.destinationPath(
-          path.join(outputdir, appname, `${appname}Helper.js`)
+          path.join(this.outputdir, appname, `${appname}Helper.js`)
         ),
         {}
       ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningRenderer.js'),
         this.destinationPath(
-          path.join(outputdir, appname, `${appname}Renderer.js`)
+          path.join(this.outputdir, appname, `${appname}Renderer.js`)
         ),
         {}
       ),
       this.fs.copyTpl(
         this.templatePath('DefaultLightningSVG.svg'),
-        this.destinationPath(path.join(outputdir, appname, `${appname}.svg`)),
+        this.destinationPath(
+          path.join(this.outputdir, appname, `${appname}.svg`)
+        ),
         {}
       );
   }

--- a/src/generators/lightningComponentGenerator.ts
+++ b/src/generators/lightningComponentGenerator.ts
@@ -21,7 +21,7 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
     CreateUtil.checkInputs(this.options.componentname);
     CreateUtil.checkInputs(this.options.template);
 
-    const fileparts = path.resolve(this.options.outputdir).split(path.sep);
+    const fileparts = path.resolve(this.outputdir).split(path.sep);
 
     if (!this.options.internal) {
       if (this.options.type === 'lwc' && !fileparts.includes('lwc')) {
@@ -46,8 +46,7 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
   }
 
   public writing(): void {
-    const { template, outputdir, componentname, apiversion, type, internal } =
-      this.options;
+    const { template, componentname, type, internal } = this.options;
 
     if (type === 'aura') {
       this.sourceRootWithPartialPath(
@@ -57,68 +56,80 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
         this.fs.copyTpl(
           this.templatePath(`${template}.cmp-meta.xml`),
           this.destinationPath(
-            path.join(outputdir, componentname, `${componentname}.cmp-meta.xml`)
+            path.join(
+              this.outputdir,
+              componentname,
+              `${componentname}.cmp-meta.xml`
+            )
           ),
           {
             componentname,
             description: nls.localize('LightningComponentBundle'),
-            apiVersion: apiversion,
+            apiVersion: this.apiversion,
           }
         );
       }
       this.fs.copyTpl(
         this.templatePath(`${template}.auradoc`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.auradoc`)
+          path.join(this.outputdir, componentname, `${componentname}.auradoc`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}.cmp`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.cmp`)
+          path.join(this.outputdir, componentname, `${componentname}.cmp`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}.css`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.css`)
+          path.join(this.outputdir, componentname, `${componentname}.css`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}.design`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.design`)
+          path.join(this.outputdir, componentname, `${componentname}.design`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}.svg`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}.svg`)
+          path.join(this.outputdir, componentname, `${componentname}.svg`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}Controller.js`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}Controller.js`)
+          path.join(
+            this.outputdir,
+            componentname,
+            `${componentname}Controller.js`
+          )
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}Helper.js`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}Helper.js`)
+          path.join(this.outputdir, componentname, `${componentname}Helper.js`)
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(`${template}Renderer.js`),
         this.destinationPath(
-          path.join(outputdir, componentname, `${componentname}Renderer.js`)
+          path.join(
+            this.outputdir,
+            componentname,
+            `${componentname}Renderer.js`
+          )
         ),
         {}
       );
@@ -145,7 +156,7 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
         this.templatePath(`${template}.js`),
         this.destinationPath(
           path.join(
-            outputdir,
+            this.outputdir,
             camelCaseComponentName,
             `${camelCaseComponentName}.js`
           )
@@ -157,7 +168,7 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
         this.templatePath(`${template}.html`),
         this.destinationPath(
           path.join(
-            outputdir,
+            this.outputdir,
             camelCaseComponentName,
             `${camelCaseComponentName}.html`
           )
@@ -169,7 +180,7 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
         this.templatePath(path.join(`__tests__`, `${template}.test.js`)),
         this.destinationPath(
           path.join(
-            outputdir,
+            this.outputdir,
             camelCaseComponentName,
             `__tests__`,
             `${camelCaseComponentName}.test.js`
@@ -190,12 +201,12 @@ export default class LightningComponentGenerator extends SfdxGenerator<Lightning
           this.templatePath(`${template}.js-meta.xml`),
           this.destinationPath(
             path.join(
-              outputdir,
+              this.outputdir,
               camelCaseComponentName,
               `${camelCaseComponentName}.js-meta.xml`
             )
           ),
-          { apiVersion: apiversion, masterLabel }
+          { apiVersion: this.apiversion, masterLabel }
         );
       }
     }

--- a/src/generators/lightningEventGenerator.ts
+++ b/src/generators/lightningEventGenerator.ts
@@ -20,32 +20,33 @@ export default class LightningEventGenerator extends SfdxGenerator<LightningEven
     CreateUtil.checkInputs(this.options.eventname);
     CreateUtil.checkInputs(this.options.template);
 
-    const fileparts = path.resolve(this.options.outputdir).split(path.sep);
+    const fileparts = path.resolve(this.outputdir).split(path.sep);
     if (!this.options.internal && !fileparts.includes('aura')) {
       throw new Error(nls.localize('MissingAuraDir'));
     }
   }
 
   public writing(): void {
-    const { template, outputdir, eventname, apiversion, internal } =
-      this.options;
+    const { template, eventname, internal } = this.options;
     // tslint:disable-next-line:no-unused-expression
     if (!internal) {
       this.fs.copyTpl(
         this.templatePath('_auradefinitionbundle.evt-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, eventname, `${eventname}.evt-meta.xml`)
+          path.join(this.outputdir, eventname, `${eventname}.evt-meta.xml`)
         ),
         {
           eventname,
-          apiVersion: apiversion,
+          apiVersion: this.apiversion,
           description: nls.localize('LightningEventBundle'),
         }
       );
     }
     this.fs.copyTpl(
       this.templatePath(`${template}.evt`),
-      this.destinationPath(path.join(outputdir, eventname, `${eventname}.evt`)),
+      this.destinationPath(
+        path.join(this.outputdir, eventname, `${eventname}.evt`)
+      ),
       {}
     );
   }

--- a/src/generators/lightningInterfaceGenerator.ts
+++ b/src/generators/lightningInterfaceGenerator.ts
@@ -20,7 +20,7 @@ export default class LightningInterfaceGenerator extends SfdxGenerator<Lightning
     CreateUtil.checkInputs(this.options.interfacename);
     CreateUtil.checkInputs(this.options.template);
 
-    const fileparts = path.resolve(this.options.outputdir).split(path.sep);
+    const fileparts = path.resolve(this.outputdir).split(path.sep);
 
     if (!this.options.internal && !fileparts.includes('aura')) {
       throw new Error(nls.localize('MissingAuraDir'));
@@ -28,17 +28,20 @@ export default class LightningInterfaceGenerator extends SfdxGenerator<Lightning
   }
 
   public writing(): void {
-    const { template, outputdir, interfacename, apiversion, internal } =
-      this.options;
+    const { template, interfacename, internal } = this.options;
     // tslint:disable-next-line:no-unused-expression
     if (!internal) {
       this.fs.copyTpl(
         this.templatePath('_auradefinitionbundle.intf-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, interfacename, `${interfacename}.intf-meta.xml`)
+          path.join(
+            this.outputdir,
+            interfacename,
+            `${interfacename}.intf-meta.xml`
+          )
         ),
         {
-          apiVersion: apiversion,
+          apiVersion: this.apiversion,
           description: nls.localize('LightningInterfaceBundle'),
         }
       );
@@ -46,7 +49,7 @@ export default class LightningInterfaceGenerator extends SfdxGenerator<Lightning
     this.fs.copyTpl(
       this.templatePath(`${template}.intf`),
       this.destinationPath(
-        path.join(outputdir, interfacename, `${interfacename}.intf`)
+        path.join(this.outputdir, interfacename, `${interfacename}.intf`)
       ),
       {}
     );

--- a/src/generators/lightningTestGenerator.ts
+++ b/src/generators/lightningTestGenerator.ts
@@ -22,13 +22,13 @@ export default class LightningTestGenerator extends SfdxGenerator<LightningTestO
   }
 
   public writing(): void {
-    const { template, outputdir, testname, internal } = this.options;
+    const { template, testname, internal } = this.options;
     // tslint:disable-next-line:no-unused-expression
     if (!internal) {
       this.fs.copyTpl(
         this.templatePath('_staticresource.resource-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, `${testname}.resource-meta.xml`)
+          path.join(this.outputdir, `${testname}.resource-meta.xml`)
         ),
         {
           description: nls.localize('LightningTest'),
@@ -39,7 +39,7 @@ export default class LightningTestGenerator extends SfdxGenerator<LightningTestO
     }
     this.fs.copyTpl(
       this.templatePath(`${template}.resource`),
-      this.destinationPath(path.join(outputdir, `${testname}.resource`)),
+      this.destinationPath(path.join(this.outputdir, `${testname}.resource`)),
       { apiName: testname }
     );
   }

--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -55,15 +55,8 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
   }
 
   public writing(): void {
-    const {
-      projectname,
-      template,
-      defaultpackagedir,
-      manifest,
-      ns,
-      apiversion,
-      loginurl,
-    } = this.options;
+    const { projectname, template, defaultpackagedir, manifest, ns, loginurl } =
+      this.options;
     const folderlayout = [
       this.outputdir,
       projectname,
@@ -103,7 +96,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
         defaultpackagedir,
         namespace: ns,
         loginurl,
-        apiversion,
+        apiversion: this.apiversion,
         name: projectname,
       }
     );
@@ -114,7 +107,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
         this.destinationPath(
           path.join(this.outputdir, projectname, 'manifest', 'package.xml')
         ),
-        { apiversion }
+        { apiversion: this.apiversion }
       );
     }
 

--- a/src/generators/projectGenerator.ts
+++ b/src/generators/projectGenerator.ts
@@ -56,7 +56,6 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
 
   public writing(): void {
     const {
-      outputdir,
       projectname,
       template,
       defaultpackagedir,
@@ -66,7 +65,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       loginurl,
     } = this.options;
     const folderlayout = [
-      outputdir,
+      this.outputdir,
       projectname,
       defaultpackagedir,
       'main',
@@ -81,19 +80,24 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
     this.fs.copyTpl(
       this.templatePath(scratchDefFile),
       this.destinationPath(
-        path.join(outputdir, projectname, 'config', 'project-scratch-def.json')
+        path.join(
+          this.outputdir,
+          projectname,
+          'config',
+          'project-scratch-def.json'
+        )
       ),
       { company: (process.env.USER || 'Demo') + ' company' }
     );
     this.fs.copyTpl(
       this.templatePath(`${template}/README.md`),
-      this.destinationPath(path.join(outputdir, projectname, 'README.md')),
+      this.destinationPath(path.join(this.outputdir, projectname, 'README.md')),
       {}
     );
     this.fs.copyTpl(
       this.templatePath('sfdx-project.json'),
       this.destinationPath(
-        path.join(outputdir, projectname, 'sfdx-project.json')
+        path.join(this.outputdir, projectname, 'sfdx-project.json')
       ),
       {
         defaultpackagedir,
@@ -108,7 +112,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       this.fs.copyTpl(
         this.templatePath(manifestFile),
         this.destinationPath(
-          path.join(outputdir, projectname, 'manifest', 'package.xml')
+          path.join(this.outputdir, projectname, 'manifest', 'package.xml')
         ),
         { apiversion }
       );
@@ -118,13 +122,13 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       makeEmptyFolders(folderlayout, standardfolderarray);
 
       // Add Husky directory and hooks
-      this._createHuskyConfig(path.join(outputdir, projectname));
+      this._createHuskyConfig(path.join(this.outputdir, projectname));
 
       for (const file of vscodearray) {
         this.fs.copyTpl(
           this.templatePath(`${file}.json`),
           this.destinationPath(
-            path.join(outputdir, projectname, '.vscode', `${file}.json`)
+            path.join(this.outputdir, projectname, '.vscode', `${file}.json`)
           ),
           {}
         );
@@ -146,14 +150,26 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       this.fs.copyTpl(
         this.templatePath(path.join(template, soqlQueryFile)),
         this.destinationPath(
-          path.join(outputdir, projectname, 'scripts', 'soql', soqlQueryFile)
+          path.join(
+            this.outputdir,
+            projectname,
+            'scripts',
+            'soql',
+            soqlQueryFile
+          )
         ),
         {}
       );
       this.fs.copyTpl(
         this.templatePath(path.join(template, anonApexFile)),
         this.destinationPath(
-          path.join(outputdir, projectname, 'scripts', 'apex', anonApexFile)
+          path.join(
+            this.outputdir,
+            projectname,
+            'scripts',
+            'apex',
+            anonApexFile
+          )
         ),
         {}
       );
@@ -161,7 +177,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
         const out = file === GITIGNORE ? `.${file}` : file;
         this.fs.copyTpl(
           this.templatePath(file),
-          this.destinationPath(path.join(outputdir, projectname, out)),
+          this.destinationPath(path.join(this.outputdir, projectname, out)),
           {}
         );
       }
@@ -171,7 +187,9 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       makeEmptyFolders(folderlayout, emptyfolderarray);
       this.fs.copyTpl(
         this.templatePath('.forceignore'),
-        this.destinationPath(path.join(outputdir, projectname, '.forceignore')),
+        this.destinationPath(
+          path.join(this.outputdir, projectname, '.forceignore')
+        ),
         {}
       );
     }
@@ -180,20 +198,20 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
       makeEmptyFolders(folderlayout, analyticsfolderarray);
 
       // Add Husky directory and hooks
-      this._createHuskyConfig(path.join(outputdir, projectname));
+      this._createHuskyConfig(path.join(this.outputdir, projectname));
 
       for (const file of vscodearray) {
         this.fs.copyTpl(
           this.templatePath(`${file}.json`),
           this.destinationPath(
-            path.join(outputdir, projectname, '.vscode', `${file}.json`)
+            path.join(this.outputdir, projectname, '.vscode', `${file}.json`)
           ),
           {}
         );
       }
       // add the analytics vscode extension to the recommendations
       this.fs.extendJSON(
-        path.join(outputdir, projectname, '.vscode', 'extensions.json'),
+        path.join(this.outputdir, projectname, '.vscode', 'extensions.json'),
         {},
         (key: string, value: unknown) => {
           if (
@@ -224,7 +242,7 @@ export default class ProjectGenerator extends SfdxGenerator<ProjectOptions> {
         const out = file === GITIGNORE ? `.${file}` : file;
         this.fs.copyTpl(
           this.templatePath(file),
-          this.destinationPath(path.join(outputdir, projectname, out)),
+          this.destinationPath(path.join(this.outputdir, projectname, out)),
           {}
         );
       }

--- a/src/generators/sfdxGenerator.ts
+++ b/src/generators/sfdxGenerator.ts
@@ -44,8 +44,8 @@ export abstract class SfdxGenerator<
   ) {
     super(args, options, features);
     this.apiversion =
-      this.options.apiversion ?? TemplateService.getDefaultApiVersion();
-    this.outputdir = this.options.outputdir ?? process.cwd();
+      options.apiversion ?? TemplateService.getDefaultApiVersion();
+    this.outputdir = options.outputdir ?? process.cwd();
     this.validateOptions();
   }
 

--- a/src/generators/sfdxGenerator.ts
+++ b/src/generators/sfdxGenerator.ts
@@ -17,15 +17,14 @@ import { TemplateOptions } from '../utils/types';
 export abstract class SfdxGenerator<
   TOptions extends TemplateOptions
 > extends Generator<Generator.GeneratorOptions> {
-  options!: TOptions & {
-    apiversion: string;
-    outputdir: string;
-  };
+  options!: TOptions;
 
   /**
    * Set by sourceRootWithPartialPath called in generator
    */
   public builtInTemplatesRootPath?: string;
+  protected outputdir: string;
+  protected apiversion: string;
 
   /**
    * The constructor for the SFDXGenerator.
@@ -44,9 +43,9 @@ export abstract class SfdxGenerator<
     }
   ) {
     super(args, options, features);
-    this.options.apiversion =
+    this.apiversion =
       this.options.apiversion ?? TemplateService.getDefaultApiVersion();
-    this.options.outputdir = this.options.outputdir ?? process.cwd();
+    this.outputdir = this.options.outputdir ?? process.cwd();
     this.validateOptions();
   }
 

--- a/src/generators/staticResourceGenerator.ts
+++ b/src/generators/staticResourceGenerator.ts
@@ -28,7 +28,7 @@ export default class StaticResourceGenerator extends SfdxGenerator<StaticResourc
   }
 
   public writing(): void {
-    const { outputdir, resourcename, contenttype } = this.options;
+    const { resourcename, contenttype } = this.options;
 
     const ext = extension(contenttype);
 
@@ -36,21 +36,27 @@ export default class StaticResourceGenerator extends SfdxGenerator<StaticResourc
       // For types that we have default file, write that (js, css, txt, json)
       this.fs.copyTpl(
         this.templatePath(`empty.${ext}`),
-        this.destinationPath(path.join(outputdir, `${resourcename}.${ext}`)),
+        this.destinationPath(
+          path.join(this.outputdir, `${resourcename}.${ext}`)
+        ),
         {}
       );
     } else if (ext === 'zip') {
       // For zip files, write an empty js file in a folder
       this.fs.copyTpl(
         this.templatePath('_gitkeep'),
-        this.destinationPath(path.join(outputdir, resourcename, '.gitkeep')),
+        this.destinationPath(
+          path.join(this.outputdir, resourcename, '.gitkeep')
+        ),
         {}
       );
     } else {
       // For all other mime types write a generic .resource file
       this.fs.copyTpl(
         this.templatePath('empty.resource'),
-        this.destinationPath(path.join(outputdir, `${resourcename}.resource`)),
+        this.destinationPath(
+          path.join(this.outputdir, `${resourcename}.resource`)
+        ),
         {}
       );
     }
@@ -58,7 +64,7 @@ export default class StaticResourceGenerator extends SfdxGenerator<StaticResourc
     this.fs.copyTpl(
       this.templatePath('_staticresource.resource-meta.xml'),
       this.destinationPath(
-        path.join(outputdir, `${resourcename}.resource-meta.xml`)
+        path.join(this.outputdir, `${resourcename}.resource-meta.xml`)
       ),
       {
         contentType: contenttype,

--- a/src/generators/visualforceComponentGenerator.ts
+++ b/src/generators/visualforceComponentGenerator.ts
@@ -21,17 +21,18 @@ export default class VisualforceComponentGenerator extends SfdxGenerator<Visualf
   }
 
   public writing(): void {
-    const { template, outputdir, label, apiversion, componentname } =
-      this.options;
+    const { template, label, apiversion, componentname } = this.options;
     this.fs.copyTpl(
       this.templatePath(`${template}.component`),
-      this.destinationPath(path.join(outputdir, `${componentname}.component`)),
+      this.destinationPath(
+        path.join(this.outputdir, `${componentname}.component`)
+      ),
       {}
     ),
       this.fs.copyTpl(
         this.templatePath('_component.component-meta.xml'),
         this.destinationPath(
-          path.join(outputdir, `${componentname}.component-meta.xml`)
+          path.join(this.outputdir, `${componentname}.component-meta.xml`)
         ),
         { vfLabel: label, apiVersion: apiversion }
       );

--- a/src/generators/visualforceComponentGenerator.ts
+++ b/src/generators/visualforceComponentGenerator.ts
@@ -21,7 +21,7 @@ export default class VisualforceComponentGenerator extends SfdxGenerator<Visualf
   }
 
   public writing(): void {
-    const { template, label, apiversion, componentname } = this.options;
+    const { template, label, componentname } = this.options;
     this.fs.copyTpl(
       this.templatePath(`${template}.component`),
       this.destinationPath(
@@ -34,7 +34,7 @@ export default class VisualforceComponentGenerator extends SfdxGenerator<Visualf
         this.destinationPath(
           path.join(this.outputdir, `${componentname}.component-meta.xml`)
         ),
-        { vfLabel: label, apiVersion: apiversion }
+        { vfLabel: label, apiVersion: this.apiversion }
       );
   }
 }

--- a/src/generators/visualforcePageGenerator.ts
+++ b/src/generators/visualforcePageGenerator.ts
@@ -21,16 +21,18 @@ export default class VisualforcePageGenerator extends SfdxGenerator<VisualforceP
   }
 
   public writing(): void {
-    const { template, outputdir, label, apiversion, pagename } = this.options;
+    const { template, label, pagename } = this.options;
     this.fs.copyTpl(
       this.templatePath(`${template}.page`),
-      this.destinationPath(path.join(outputdir, `${pagename}.page`)),
+      this.destinationPath(path.join(this.outputdir, `${pagename}.page`)),
       {}
     );
     this.fs.copyTpl(
       this.templatePath('_page.page-meta.xml'),
-      this.destinationPath(path.join(outputdir, `${pagename}.page-meta.xml`)),
-      { vfLabel: label, apiVersion: apiversion }
+      this.destinationPath(
+        path.join(this.outputdir, `${pagename}.page-meta.xml`)
+      ),
+      { vfLabel: label, apiVersion: this.apiversion }
     );
   }
 }

--- a/test/generators/sfdxGenerator.test.ts
+++ b/test/generators/sfdxGenerator.test.ts
@@ -22,11 +22,13 @@ describe('SfdxGenerator', () => {
   class MyGenerator extends SfdxGenerator<MyTemplateOptions> {
     public validateOptions() {}
     public writing() {
-      this.doWriting(this.options);
+      this.doWriting({
+        ...this.options,
+        apiversion: this.apiversion,
+        outputdir: this.outputdir,
+      });
     }
-    public doWriting(
-      options: MyTemplateOptions & { apiversion: string; outputdir: string }
-    ) {}
+    public doWriting(options: MyTemplateOptions) {}
   }
   const testEnv = YeomanEnvironment.createEnv();
   testEnv.cwd = process.cwd();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.settings.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,12 +133,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
-
-"@babel/helper-validator-identifier@^7.18.6":
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
@@ -157,21 +152,12 @@
     "@babel/traverse" "^7.17.0"
     "@babel/types" "^7.17.0"
 
-"@babel/highlight@^7.10.4":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz"
   integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -988,16 +974,7 @@
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.5.41":
-  version "1.5.44"
-  resolved "https://registry.npmjs.org/@salesforce/kit/-/kit-1.5.44.tgz"
-  integrity sha512-QHwmJFgvF0YyBAvPkSMy2opyIgKzATF8lwYHewCr2obyqDiVi9OJkYWgQETkKTpfLzSjWqdsfiVAdlnRcj+xQQ==
-  dependencies:
-    "@salesforce/ts-types" "^1.5.20"
-    shx "^0.3.3"
-    tslib "^2.2.0"
-
-"@salesforce/kit@^1.7.1":
+"@salesforce/kit@^1.5.41", "@salesforce/kit@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.7.1.tgz#2337ae354409726f1822f1b03a3d7073e84cd249"
   integrity sha512-XbLtEgMNBGZqtY/OldEru+LzASS3o37MZ6eNlSG19eAroGqFdlr4pzZUD/UaWSt6E0s0arj4IwAP5/hQLbrBZw==
@@ -1016,14 +993,7 @@
   resolved "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.1.3.tgz"
   integrity sha512-XWohlOT2oQDqAJH00OXS3f2MGjkwZ6pr4emnnkHSQbg7UdGW0rvGpEnRKqBbDUfZ4K5YKSo9Gj216ZtaP3JLXg==
 
-"@salesforce/ts-types@^1.5.20":
-  version "1.5.20"
-  resolved "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.5.20.tgz"
-  integrity sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==
-  dependencies:
-    tslib "^2.2.0"
-
-"@salesforce/ts-types@^1.7.0":
+"@salesforce/ts-types@^1.5.20", "@salesforce/ts-types@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.0.tgz#0ec743b324a0d39b13ac681132042742e9a43d0f"
   integrity sha512-8bLGBZCk7T/tkfXP66r5Pkhn3CjfNQIOy6B0Z1rvam5RgqWtYYcubF7eSLSj7bop/q7tA8+R6bNJmjATX6hTqA==
@@ -1117,12 +1087,7 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz"
-  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
-
-"@types/chai@^4.2.11":
+"@types/chai@*", "@types/chai@^4.2.11":
   version "4.3.3"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz"
   integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
@@ -1193,12 +1158,7 @@
     "@types/through" "*"
     rxjs "^7.2.0"
 
-"@types/json-schema@*":
-  version "7.0.9"
-  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz"
-  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
-
-"@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -2695,14 +2655,7 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
-  dependencies:
-    object-keys "^1.0.12"
-
-define-properties@^1.1.4:
+define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz"
   integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
@@ -2990,15 +2943,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-module-utils@^2.6.2:
-  version "2.7.3"
-  resolved "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz"
-  integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
-  dependencies:
-    debug "^3.2.7"
-    find-up "^2.1.0"
-
-eslint-module-utils@^2.7.3:
+eslint-module-utils@^2.6.2, eslint-module-utils@^2.7.3:
   version "2.7.4"
   resolved "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz"
   integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
@@ -3292,21 +3237,10 @@ fast-diff@^1.1.2:
   resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.0.3:
+fast-glob@^3.0.3, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.2.9:
-  version "3.2.11"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -3731,7 +3665,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.2.0, glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -3743,7 +3677,7 @@ glob@7.2.0, glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.2.3, glob@^7.1.2:
+glob@7.2.3, glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -3859,12 +3793,7 @@ got@^11.8.2:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
-  version "4.2.9"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz"
-  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
-
-graceful-fs@^4.2.9:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -3906,12 +3835,7 @@ has-property-descriptors@^1.0.0:
   dependencies:
     get-intrinsic "^1.1.1"
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-
-has-symbols@^1.0.3:
+has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -4039,18 +3963,10 @@ http2-wrapper@^1.0.0-beta.5.2:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
 
-https-proxy-agent@5:
+https-proxy-agent@5, https-proxy-agent@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
     agent-base "6"
     debug "4"
@@ -4260,17 +4176,10 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
-is-core-module@^2.5.0:
+is-core-module@^2.5.0, is-core-module@^2.6.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.11.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.6.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz"
-  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
   dependencies:
     has "^1.0.3"
 
@@ -5140,14 +5049,7 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^5.1.0:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
@@ -5232,6 +5134,11 @@ minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3, minipass@^3.
   integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
   dependencies:
     yallist "^4.0.0"
+
+minipass@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.1.tgz#2b9408c6e81bb8b338d600fb3685e375a370a057"
+  integrity sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==
 
 minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -5629,7 +5536,7 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -6525,14 +6432,7 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.2.0:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz"
-  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.5.5:
+rxjs@^7.2.0, rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -6574,7 +6474,7 @@ scoped-regex@^2.0.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.3.5, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -6586,7 +6486,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.7:
+semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -7013,14 +6913,14 @@ tar-stream@^2.1.4, tar-stream@^2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.0.2, tar@^6.1.0, tar@^6.1.10, tar@^6.1.11, tar@^6.1.2:
-  version "6.1.11"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+tar@^6.0.2, tar@^6.1.0, tar@^6.1.11, tar@^6.1.13, tar@^6.1.2:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
+  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^3.0.0"
+    minipass "^4.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
@@ -7167,15 +7067,10 @@ tslib@^1, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
-tslib@^2.1.0, tslib@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -7258,15 +7153,10 @@ typedoc@0.22.18:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@^4.1.3, typescript@^4.4.3, typescript@^4.6.4:
+typescript@^4.1.3, typescript@^4.4.3, typescript@^4.4.4, typescript@^4.6.4:
   version "4.8.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
-
-typescript@^4.4.4:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### What does this PR do?
interface for TemplateOptions has apiVersion and outputDir as optional.  But SfdxGenerator is typed to make them required, so catch-22.

This moves those to instance props that are defaulted in the ctor.

unrelated:
`shelljs` is only used in some npm script, so it moved to devDeps
I bumped `tar` to help with an error related to node18 https://github.com/isaacs/node-tar/issues/321
### What issues does this PR fix or reference?

needed for [@W-11976561@](https://gus.lightning.force.com/a07EE00001AE28uYAD) to remove a bunch of type-ignoring code