### PR TITLE
fix: bump dep for @salesforce/sfdx-lwc-jest to 3.1.0

### DIFF
--- a/src/templates/project/package.json
+++ b/src/templates/project/package.json
@@ -16,18 +16,18 @@
     "precommit": "lint-staged"
   },
   "devDependencies": {
-    "@lwc/eslint-plugin-lwc": "^1.6.3",
-    "@prettier/plugin-xml": "^3.2.1",
-    "@salesforce/eslint-config-lwc": "^3.5.2",
-    "@salesforce/eslint-plugin-aura": "^2.1.0",
+    "@lwc/eslint-plugin-lwc": "^1.1.2",
+    "@prettier/plugin-xml": "^3.2.2",
+    "@salesforce/eslint-config-lwc": "^3.2.3",
+    "@salesforce/eslint-plugin-aura": "^2.0.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
-    "@salesforce/sfdx-lwc-jest": "^1.4.1",
-    "eslint": "^8.49.0",
-    "eslint-plugin-import": "^2.28.1",
-    "eslint-plugin-jest": "^27.2.3",
+    "@salesforce/sfdx-lwc-jest": "^3.1.0",
+    "eslint": "^8.11.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jest": "^27.6.0",
     "husky": "^8.0.3",
-    "lint-staged": "^14.0.1",
-    "prettier": "^3.0.3",
+    "lint-staged": "^15.1.0",
+    "prettier": "^3.1.0",
     "prettier-plugin-apex": "^2.0.1"
   },
   "lint-staged": {


### PR DESCRIPTION
### What does this PR do?
bumps @salesforce/sfdx-lwc-jest to 3.1.0 so that module jest-environment-jsdom is installed
Bumps other dev deps to latest version

### What issues does this PR fix or reference?
@W-14512085@ [#5239](https://github.com/forcedotcom/salesforcedx-vscode/issues/5239)

