### PR TITLE
fix: update slack secret var bump to major version

### DIFF
--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -23,4 +23,4 @@ jobs:
               "result": "${{ github.event.workflow_run.conclusion }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.IDEE_RELEASE_ALERT_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.IDEE_MAIN_SLACK_WEBHOOK }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/templates",
-  "version": "60.1.2",
+  "version": "61.0.0",
   "salesforceApiVersion": "61",
   "description": "Salesforce JS library for templates",
   "bugs": "https://github.com/forcedotcom/salesforcedx-templates/issues",


### PR DESCRIPTION
@W-15476622@
changed the secret name used for slack notification
bump version to 61.0.0