### PR TITLE
chore: make packageJson bundleable

### DIFF
--- a/src/generators/baseGenerator.ts
+++ b/src/generators/baseGenerator.ts
@@ -12,6 +12,7 @@ import { CreateOutput, TemplateOptions } from '../utils/types';
 import { renderFile } from 'ejs';
 import { nls } from '../i18n';
 import { loadCustomTemplatesGitRepo } from '../service/gitRepoUtils';
+import * as packageJson from '../../package.json';
 
 async function outputFile(file: string, data: string): Promise<void> {
   const dir = path.dirname(file);
@@ -67,8 +68,7 @@ export async function setCustomTemplatesRootPathOrGitRepo(
  * Look up package version of @salesforce/templates package to supply a default API version
  */
 export function getDefaultApiVersion(): string {
-  const packageJsonPath = path.join('..', '..', 'package.json');
-  const versionTrimmed = require(packageJsonPath).salesforceApiVersion.trim();
+  const versionTrimmed = packageJson.salesforceApiVersion.trim();
   return `${versionTrimmed.split('.')[0]}.0`;
 }
 


### PR DESCRIPTION
### What does this PR do?
package.json cannot be bundled due to the previous usage. This PR makes package.json bundle-able, so core extension can use it seamlessly.

### What issues does this PR fix or reference?
@W-15736930@