### PR TITLE
chore: pin eslint to v8 for cli dependants

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,8 @@ updates:
       # no release for dev-deps
       prefix-development: chore(dev-deps)
     ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
       - dependency-name: '@salesforce/dev-scripts'
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']

--- a/src/templates/project/package.json
+++ b/src/templates/project/package.json
@@ -22,7 +22,7 @@
     "@salesforce/eslint-plugin-aura": "^2.0.0",
     "@salesforce/eslint-plugin-lightning": "^1.0.0",
     "@salesforce/sfdx-lwc-jest": "^6.0.1",
-    "eslint": "^9.13.0",
+    "eslint": "8.57.1",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^28.8.1",
     "husky": "^9.1.5",


### PR DESCRIPTION
### What does this PR do?
pin eslint to v8 for cli dependants since v8 is no longer minor releasing. dependabot does not look to comprehend ignoring major bump for eslint here. 

refer to #630 for more info.

### What issues does this PR fix or reference?
[skip-validate-pr]