### PR TITLE
feat: exclude .sf folder from search

### DIFF
--- a/src/templates/project/settings.json
+++ b/src/templates/project/settings.json
@@ -2,6 +2,7 @@
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,
+    "**/.sf": true,
     "**/.sfdx": true
   }
 }


### PR DESCRIPTION
Adds a config rule that excludes the content of the `.sf` folder from VSCode search (just like `.sfdx` is already ignored).

[skip-validate-pr]