### PR TITLE
fix: adding gitignore on template generation for ui bundles @W-21940169@

### DIFF
--- a/scripts/copy-templates.js
+++ b/scripts/copy-templates.js
@@ -197,16 +197,6 @@ function copyTemplate(config) {
       }
     }
 
-    // npm strips .gitignore during publish; restore it for project templates
-    // by copying the standard project gitignore template.
-    if (config.destSubpath.startsWith('project/')) {
-      const gitignoreSrc = path.join(templatesRoot, 'project', 'gitignore');
-      const gitignoreDest = path.join(destDir, '.gitignore');
-      if (fs.existsSync(gitignoreSrc) && !fs.existsSync(gitignoreDest)) {
-        fs.copyFileSync(gitignoreSrc, gitignoreDest);
-      }
-    }
-
     console.log(
       `Copied ${config.packageName} to src/templates/${config.destSubpath}`
     );

--- a/src/utils/uiBundleTemplateUtils.ts
+++ b/src/utils/uiBundleTemplateUtils.ts
@@ -372,6 +372,19 @@ export async function generateBuiltInFullTemplate(
     renderEjs,
     onFileCreated,
   });
+
+  // npm renames .gitignore → .npmignore on install, so template packages
+  // lose their .gitignore. Use the standard project gitignore template
+  // (stored without the dot, so npm leaves it alone).
+  const gitignoreDest = path.join(projectDir, '.gitignore');
+  if (!fs.existsSync(gitignoreDest)) {
+    const gitignoreSrc = path.join(templateDir, '..', 'gitignore');
+    if (fs.existsSync(gitignoreSrc)) {
+      const content = await readFile(gitignoreSrc, 'utf8');
+      await writeFile(gitignoreDest, content, 'utf8');
+      onFileCreated(gitignoreDest);
+    }
+  }
 }
 
 export type GenerateFromProjectTemplateDirOptions = {


### PR DESCRIPTION
## Summary
- npm renames `.gitignore` to `.npmignore` on install, so react full templates (`reactinternalapp`, `reactexternalapp`) sourced from npm packages lose their `.gitignore`.
- After walking the template dir in `generateBuiltInFullTemplate`, fall back to `project/gitignore` (which survives npm since it has no dot prefix) to generate `.gitignore` in the output project.
- Remove the broken `copy-templates.js` workaround that placed a `.gitignore` in react template dirs at build time — npm just renamed it away on install.

## Test plan
- [x] All 137 existing tests pass
- [x] `verify-for-bundling.js` comparison passes
- [x] Verify `.gitignore` is present after generating `reactinternalapp` and `reactexternalapp` projects from a published package

@W-21940169@