### PR TITLE
fix: use prefix when referencing prompt template input vars @W-22012138

### DIFF
--- a/src/templates/project/agent/md/aab/Local_Info_Agent.agent
+++ b/src/templates/project/agent/md/aab/Local_Info_Agent.agent
@@ -181,7 +181,7 @@ topic local_events:
             check_events: @actions.check_events
                 description: "Look up local events matching the guest's interests"
                 available when @variables.guest_interests != ""
-                with Event_Type = @variables.guest_interests
+                with "Input:Event_Type" = @variables.guest_interests
 
     actions:
         check_events:


### PR DESCRIPTION
Updated Local_Info_Agent to use the "Input:" prefix when referencing prompt template input vars.  Without this change, there will be linting errors in the agent script file of a newly generated agent project due to recent changes in v2 agent script parser.

@W-22012138@
