### PR TITLE
feat: update default API version to 67.0 - W-22858527

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,7 +6,7 @@
  */
 import * as path from 'path';
 
-export const DEFAULT_API_VERSION = '66.0';
+export const DEFAULT_API_VERSION = '67.0';
 
 export const UI_BUNDLES_DIR = 'uiBundles';
 


### PR DESCRIPTION
Bumps `DEFAULT_API_VERSION` from `66.0` to `67.0` in `src/utils/constants.ts` (line 9) — the only reference in the codebase.

### What issues does this PR fix or reference?
@W-22858527@

🤖 Generated with [Claude Code](https://claude.com/claude-code)