### PR TITLE
feat: add apex templates for common apex class types - W-23219494

### DIFF
--- a/src/generators/apexClassGenerator.ts
+++ b/src/generators/apexClassGenerator.ts
@@ -13,6 +13,12 @@ export default class ApexClassGenerator extends BaseGenerator<ApexClassOptions> 
   public validateOptions(): void {
     CreateUtil.checkInputs(this.options.template);
     CreateUtil.checkInputs(this.options.classname);
+    if (
+      this.options.template === 'Batchable' &&
+      this.options.sobjecttype?.trim()
+    ) {
+      CreateUtil.checkSObjectType(this.options.sobjecttype.trim());
+    }
   }
 
   public async generate(): Promise<void> {
@@ -25,7 +31,7 @@ export default class ApexClassGenerator extends BaseGenerator<ApexClassOptions> 
       {
         apiName: classname,
         ...(template === 'Batchable' && {
-          sobjectType: sobjecttype ?? 'SObject',
+          sobjectType: sobjecttype?.trim() || 'SObject',
         }),
       }
     );

--- a/src/generators/apexClassGenerator.ts
+++ b/src/generators/apexClassGenerator.ts
@@ -22,7 +22,12 @@ export default class ApexClassGenerator extends BaseGenerator<ApexClassOptions> 
     await this.render(
       this.templatePath(`${template}.cls`),
       this.destinationPath(path.join(this.outputdir, `${classname}.cls`)),
-      { apiName: classname, sobjectType: sobjecttype || 'SObject' }
+      {
+        apiName: classname,
+        ...(template === 'Batchable' && {
+          sobjectType: sobjecttype ?? 'SObject',
+        }),
+      }
     );
 
     await this.render(

--- a/src/generators/apexClassGenerator.ts
+++ b/src/generators/apexClassGenerator.ts
@@ -16,13 +16,13 @@ export default class ApexClassGenerator extends BaseGenerator<ApexClassOptions> 
   }
 
   public async generate(): Promise<void> {
-    const { template, classname } = this.options;
+    const { template, classname, sobjecttype } = this.options;
     this.sourceRootWithPartialPath('apexclass');
 
     await this.render(
       this.templatePath(`${template}.cls`),
       this.destinationPath(path.join(this.outputdir, `${classname}.cls`)),
-      { apiName: classname }
+      { apiName: classname, sobjectType: sobjecttype || 'SObject' }
     );
 
     await this.render(

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -62,6 +62,9 @@ export const messages = {
 
   AlphaNumericValidationError: '%s must contain only alphanumeric characters.',
 
+  InvalidSObjectType:
+    'Invalid sobjecttype "%s". It must be a valid SObject API name: start with a letter, contain only letters, numbers, and underscores, and not end with an underscore.',
+
   InvalidLightningEmbeddingSrcUrl:
     'The --src flag must be an absolute https URL (e.g., https://app.example.com). Plain http is only allowed for localhost or 127.0.0.1.',
   InvalidLightningEmbeddingSrcChar:

--- a/src/templates/apexclass/Batchable.cls
+++ b/src/templates/apexclass/Batchable.cls
@@ -1,6 +1,7 @@
 public with sharing class <%= apiName %> implements Database.Batchable<<%= sobjectType %>>, Database.RaisesPlatformEvents {
 
     public Database.QueryLocator start(Database.BatchableContext context) {
+        // TODO: add a WHERE clause to filter records
         return Database.getQueryLocator([SELECT Id FROM <%= sobjectType %>]);
     }
 

--- a/src/templates/apexclass/Batchable.cls
+++ b/src/templates/apexclass/Batchable.cls
@@ -1,7 +1,7 @@
 public with sharing class <%= apiName %> implements Database.Batchable<<%= sobjectType %>>, Database.RaisesPlatformEvents {
 
     public Database.QueryLocator start(Database.BatchableContext context) {
-        return Database.getQueryLocator('SELECT Id FROM <%= sobjectType %>');
+        return Database.getQueryLocator([SELECT Id FROM <%= sobjectType %>]);
     }
 
     public void execute(Database.BatchableContext context, List<<%= sobjectType %>> scope) {

--- a/src/templates/apexclass/Batchable.cls
+++ b/src/templates/apexclass/Batchable.cls
@@ -1,0 +1,14 @@
+public with sharing class <%= apiName %> implements Database.Batchable<<%= sobjectType %>>, Database.RaisesPlatformEvents {
+
+    public Database.QueryLocator start(Database.BatchableContext context) {
+        return Database.getQueryLocator('SELECT Id FROM <%= sobjectType %>');
+    }
+
+    public void execute(Database.BatchableContext context, List<<%= sobjectType %>> scope) {
+
+    }
+
+    public void finish(Database.BatchableContext context) {
+
+    }
+}

--- a/src/templates/apexclass/Queueable.cls
+++ b/src/templates/apexclass/Queueable.cls
@@ -1,0 +1,12 @@
+public with sharing class <%= apiName %> implements Queueable, Finalizer {
+
+    public void execute(QueueableContext context) {
+        System.attachFinalizer(this);
+    }
+
+    public void execute(FinalizerContext context) {
+        if (context.getResult() == ParentJobResult.UNHANDLED_EXCEPTION ) {
+           // handle failure
+        }
+    }
+}

--- a/src/templates/apexclass/Queueable.cls
+++ b/src/templates/apexclass/Queueable.cls
@@ -2,10 +2,11 @@ public with sharing class <%= apiName %> implements Queueable, Finalizer {
 
     public void execute(QueueableContext context) {
         System.attachFinalizer(this);
+        // TODO: implement job logic here
     }
 
     public void execute(FinalizerContext context) {
-        if (context.getResult() == ParentJobResult.UNHANDLED_EXCEPTION ) {
+        if (context.getResult() == ParentJobResult.UNHANDLED_EXCEPTION) {
            // handle failure
         }
     }

--- a/src/utils/createUtil.ts
+++ b/src/utils/createUtil.ts
@@ -32,6 +32,14 @@ export class CreateUtil {
     return '';
   }
 
+  /** Validate an SObject API name (e.g. Account, MyObject__c, ns__MyObject__c). */
+  public static checkSObjectType(sobjectType: string): void {
+    const sObjectRegExp = /^[A-Za-z]\w*$/;
+    if (!sObjectRegExp.test(sobjectType) || sobjectType.endsWith('_')) {
+      throw new Error(nls.localize('InvalidSObjectType', sobjectType));
+    }
+  }
+
   // TODO: switch filetype to a string instead of regex
   public static getCommandTemplatesForFiletype(
     filetype: RegExp,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -123,19 +123,27 @@ export interface AnalyticsTemplateOptions extends TemplateOptions {
   templatename: string;
 }
 
-export interface ApexClassOptions extends TemplateOptions {
+type ApexClassBaseOptions = TemplateOptions & { classname: string };
+
+type NonBatchableApexClassOptions = ApexClassBaseOptions & {
   template:
     | 'DefaultApexClass'
     | 'BasicUnitTest'
     | 'ApexUnitTest'
     | 'ApexException'
     | 'InboundEmailService'
-    | 'Queueable'
-    | 'Batchable';
-  classname: string;
-  /** SObject type for the Batchable template. Defaults to 'SObject'. */
+    | 'Queueable';
+  sobjecttype?: never;
+};
+
+type BatchableApexClassOptions = ApexClassBaseOptions & {
+  template: 'Batchable';
   sobjecttype?: string;
-}
+};
+
+export type ApexClassOptions =
+  | NonBatchableApexClassOptions
+  | BatchableApexClassOptions;
 
 type ApexTriggerEvent =
   | 'before insert'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -129,8 +129,12 @@ export interface ApexClassOptions extends TemplateOptions {
     | 'BasicUnitTest'
     | 'ApexUnitTest'
     | 'ApexException'
-    | 'InboundEmailService';
+    | 'InboundEmailService'
+    | 'Queueable'
+    | 'Batchable';
   classname: string;
+  /** SObject type for the Batchable template. Defaults to 'SObject'. */
+  sobjecttype?: string;
 }
 
 type ApexTriggerEvent =

--- a/test/service/templateService.test.ts
+++ b/test/service/templateService.test.ts
@@ -172,6 +172,47 @@ describe('TemplateService', () => {
         expectedMetaContent
       );
     });
+
+    it('should create a Batchable apex class with a custom __c sobjecttype', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(TemplateType.ApexClass, {
+        template: 'Batchable',
+        classname: 'MyBatchable',
+        sobjecttype: 'My_Object__c',
+        outputdir,
+      });
+      const file = path.join(outputdir, 'MyBatchable.cls');
+      assertFileContent(file, 'Database.Batchable<My_Object__c>');
+      assertFileContent(file, 'List<My_Object__c> scope');
+      assertFileContent(file, 'SELECT Id FROM My_Object__c');
+    });
+
+    it('should default to SObject when sobjecttype is an empty string', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(TemplateType.ApexClass, {
+        template: 'Batchable',
+        classname: 'MyBatchable',
+        sobjecttype: '   ',
+        outputdir,
+      });
+      const file = path.join(outputdir, 'MyBatchable.cls');
+      assertFileContent(file, 'Database.Batchable<SObject>');
+      assertFileContent(file, 'SELECT Id FROM SObject');
+    });
+
+    it('should reject an invalid sobjecttype', () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      chai
+        .expect(() =>
+          templateService.create(TemplateType.ApexClass, {
+            template: 'Batchable',
+            classname: 'MyBatchable',
+            sobjecttype: 'My Object',
+            outputdir,
+          })
+        )
+        .to.throw(nls.localize('InvalidSObjectType', 'My Object'));
+    });
   });
 
   describe('create custom template', () => {

--- a/test/service/templateService.test.ts
+++ b/test/service/templateService.test.ts
@@ -106,6 +106,54 @@ describe('TemplateService', () => {
     });
   });
 
+  describe('create apex class templates', () => {
+    const outputdir = path.join('testsoutput', 'apexClassTemplates');
+
+    afterEach(async () => {
+      await remove(outputdir);
+    });
+
+    it('should create a Queueable apex class', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(TemplateType.ApexClass, {
+        template: 'Queueable',
+        classname: 'MyQueueable',
+        outputdir,
+      });
+      assertFileContent(
+        path.join(outputdir, 'MyQueueable.cls'),
+        'public with sharing class MyQueueable implements Queueable, Finalizer'
+      );
+    });
+
+    it('should create a Batchable apex class defaulting to SObject', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(TemplateType.ApexClass, {
+        template: 'Batchable',
+        classname: 'MyBatchable',
+        outputdir,
+      });
+      const file = path.join(outputdir, 'MyBatchable.cls');
+      assertFileContent(file, 'Database.Batchable<SObject>');
+      assertFileContent(file, 'List<SObject> scope');
+      assertFileContent(file, 'SELECT Id FROM SObject');
+    });
+
+    it('should create a Batchable apex class with a custom sobjecttype', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(TemplateType.ApexClass, {
+        template: 'Batchable',
+        classname: 'MyBatchable',
+        sobjecttype: 'Account',
+        outputdir,
+      });
+      const file = path.join(outputdir, 'MyBatchable.cls');
+      assertFileContent(file, 'Database.Batchable<Account>');
+      assertFileContent(file, 'List<Account> scope');
+      assertFileContent(file, 'SELECT Id FROM Account');
+    });
+  });
+
   describe('create custom template', () => {
     const TEST_CUSTOM_TEMPLATES_REPO =
       'https://github.com/forcedotcom/salesforcedx-templates/tree/main/test/custom-templates';
@@ -1209,9 +1257,7 @@ describe('TemplateService', () => {
     });
 
     it('should create UIBundle', async () => {
-      await remove(
-        path.join('testsoutput', 'libraryCreate', 'uiBundles')
-      );
+      await remove(path.join('testsoutput', 'libraryCreate', 'uiBundles'));
       const templateService = TemplateService.getInstance();
       const result = await templateService.create(TemplateType.UIBundle, {
         bundlename: 'LibraryCreateUIBundle',
@@ -1235,9 +1281,7 @@ describe('TemplateService', () => {
     });
 
     it('should create UIBundle (reactbasic)', async () => {
-      await remove(
-        path.join('testsoutput', 'libraryCreate', 'uiBundles')
-      );
+      await remove(path.join('testsoutput', 'libraryCreate', 'uiBundles'));
       const templateService = TemplateService.getInstance();
       const result = await templateService.create(TemplateType.UIBundle, {
         bundlename: 'LibraryCreateReactApp',

--- a/test/service/templateService.test.ts
+++ b/test/service/templateService.test.ts
@@ -113,6 +113,14 @@ describe('TemplateService', () => {
       await remove(outputdir);
     });
 
+    const expectedMetaContent = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">',
+      `    <apiVersion>${apiVersion}</apiVersion>`,
+      '    <status>Active</status>',
+      '</ApexClass>',
+    ].join('\n');
+
     it('should create a Queueable apex class', async () => {
       const templateService = TemplateService.getInstance(process.cwd());
       await templateService.create(TemplateType.ApexClass, {
@@ -123,6 +131,10 @@ describe('TemplateService', () => {
       assertFileContent(
         path.join(outputdir, 'MyQueueable.cls'),
         'public with sharing class MyQueueable implements Queueable, Finalizer'
+      );
+      assertFileContent(
+        path.join(outputdir, 'MyQueueable.cls-meta.xml'),
+        expectedMetaContent
       );
     });
 
@@ -137,6 +149,10 @@ describe('TemplateService', () => {
       assertFileContent(file, 'Database.Batchable<SObject>');
       assertFileContent(file, 'List<SObject> scope');
       assertFileContent(file, 'SELECT Id FROM SObject');
+      assertFileContent(
+        path.join(outputdir, 'MyBatchable.cls-meta.xml'),
+        expectedMetaContent
+      );
     });
 
     it('should create a Batchable apex class with a custom sobjecttype', async () => {
@@ -151,6 +167,10 @@ describe('TemplateService', () => {
       assertFileContent(file, 'Database.Batchable<Account>');
       assertFileContent(file, 'List<Account> scope');
       assertFileContent(file, 'SELECT Id FROM Account');
+      assertFileContent(
+        path.join(outputdir, 'MyBatchable.cls-meta.xml'),
+        expectedMetaContent
+      );
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Adds two Apex class templates: **Batchable** and **Queueable**.  The goal is to scaffold these classes *the right way* so the user (or coding agent) has a starting point already follows current best practices.

#### What's included
- **`Batchable.cls`**: strongly typed `Database.Batchable<SObject>` with a typed `List<SObject>` scope, inline (compile-checked) SOQL instead of a dynamic string query, and `Database.RaisesPlatformEvents` so batch iteration failures surface as platform events.
- **`Queueable.cls`**: implements `Finalizer` and attaches it, so post-job logic runs reliably even after an unhandled exception; `UNHANDLED_EXCEPTION` is handled explicitly.
- New optional `sobjecttype` option on `ApexClassOptions` (defaults to `SObject`), the two new `template` values, and tests.

#### Rollout : This is the first of two PRs
1. **This PR (`salesforcedx-templates`):** the raw templates. No user-facing surface yet.
2. **Follow-up (`salesforcedx-vscode`):** enable them in the Command Palette (`SFDX: Create Apex Class`) entries, localized descriptions, and an SObject prompt for Batchable.

#### Open question: Do we want to make the library hermetic?
A template today is just a `.cls` with no description, labels, i18n, or declared inputs.  Every consumer hardcodes that info, which is why this takes two PRs and the repos can drift.

**Is there any appetite to co-locate each template's content + metadata + i18n** as the single source of truth in the templates repository? Then one PR here would propagate everywhere: label, description, translations, and required inputs included. I know there have been some challenges choreographing sequences of changes which rely on templates lib; perhaps this could alleviate some future headaches.

### What issues does this PR fix or reference?
#848

---

**Adopted from #853** by @mitchspano — commits preserved with author credit. Replayed onto main for internal CI / AI review.

### Reviewer notes

**medium** `Batchable.cls:4` — `SELECT Id FROM SObject` has no WHERE clause; generates a query over all records. Added TODO comment to prompt developer to add a filter.

**medium** `Queueable.cls:1` — implementing `Finalizer` on same class loses instance state between transactions (finalizer runs in a separate transaction). Consider extracting to a separate class for stateful patterns.

**medium** `Batchable.cls:1` — `with sharing` on async classes applies the enqueueing user's sharing rules, which can silently restrict batch data access in scheduled/system contexts. Worth documenting in generated comments for awareness.

**medium** `src/utils/types.ts` — `sobjecttype?: string` is valid for all templates but only consumed by `Batchable`. No runtime error for other templates, but a discriminated union would make intent clearer. **Resolved:** `ApexClassOptions` is now a discriminated union — `sobjecttype?: never` on non-Batchable, `?: string` only on `Batchable`.

**medium** `apexClassGenerator.ts` — empty-string `sobjecttype` bypassed `??` and rendered invalid Apex (`Database.Batchable<>`). **Resolved:** generator uses `sobjecttype?.trim() || 'SObject'`, defaulting empty/whitespace to `SObject`.

**medium** `apexClassGenerator.ts` — `sobjecttype` was unvalidated, allowing invalid Apex identifiers (`'My Object'`, `'123Invalid'`). **Resolved:** added `CreateUtil.checkSObjectType`, called from `validateOptions` for `Batchable`. Did not reuse `checkInputs` (rejects `__`, would break valid custom objects like `My_Object__c`); new validator allows custom/namespaced objects while rejecting bad identifiers.

### What issues does this PR fix or reference?

@W-23219494@

Co-authored-by: Mitch Spano <mitch@sre.ai>

