### PR TITLE
feat(ui-bundle): add vuebasic generator + metadata content assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@salesforce/ui-bundle-template-app-react-template-b2x": "^10.12.2",
     "@salesforce/ui-bundle-template-base-angular-app": "^11.1.0",
     "@salesforce/ui-bundle-template-base-react-app": "^10.24.0",
+    "@salesforce/ui-bundle-template-base-vue-app": "^11.5.0",
     "@salesforce/ui-bundle-template-base-web-app": "^10.24.0",
     "@types/chai-as-promised": "^7.1.8",
     "@types/ejs": "^3.1.5",

--- a/scripts/copy-templates.js
+++ b/scripts/copy-templates.js
@@ -83,6 +83,20 @@ const TEMPLATES = [
       ),
     destSubpath: 'uiBundles/angularbasic',
   },
+  {
+    packageName: '@salesforce/ui-bundle-template-base-vue-app',
+    getSourceDir: (packageDir) =>
+      path.join(
+        packageDir,
+        'src',
+        'force-app',
+        'main',
+        'default',
+        'uiBundles',
+        'base-vue-app'
+      ),
+    destSubpath: 'uiBundles/vuebasic',
+  },
   // Project templates (reactinternalapp, reactexternalapp)
   {
     packageName: '@salesforce/ui-bundle-template-app-react-template-b2e',

--- a/src/generators/uiBundleGenerator.ts
+++ b/src/generators/uiBundleGenerator.ts
@@ -44,6 +44,9 @@ export default class UIBundleGenerator extends BaseGenerator<UIBundleOptions> {
       case 'angularbasic':
         await this.generateAngularBasic(bundleDir, bundlename, masterLabel);
         break;
+      case 'vuebasic':
+        await this.generateVueBasic(bundleDir, bundlename, masterLabel);
+        break;
       default:
         await this.generateDefault(bundleDir, bundlename, masterLabel);
     }
@@ -133,6 +136,35 @@ export default class UIBundleGenerator extends BaseGenerator<UIBundleOptions> {
       templatePath,
       bundleDir,
       new Set(['_uibundle.uibundle-meta.xml', 'package.json', 'angular.json'])
+    );
+  }
+
+  private async generateVueBasic(
+    bundleDir: string,
+    bundlename: string,
+    masterLabel: string
+  ): Promise<void> {
+    this.sourceRootWithPartialPath(path.join('uiBundles', 'vuebasic'));
+
+    await this.render(
+      this.templatePath('_uibundle.uibundle-meta.xml'),
+      this.destinationPath(
+        path.join(bundleDir, `${bundlename}.uibundle-meta.xml`)
+      ),
+      { apiVersion: this.apiversion, masterLabel }
+    );
+
+    await this.render(
+      this.templatePath('package.json'),
+      this.destinationPath(path.join(bundleDir, 'package.json')),
+      { bundlename }
+    );
+
+    const templatePath = this.sourceRoot();
+    await this.copyDirectoryRecursive(
+      templatePath,
+      bundleDir,
+      new Set(['_uibundle.uibundle-meta.xml', 'package.json'])
     );
   }
 

--- a/test/service/templateService.test.ts
+++ b/test/service/templateService.test.ts
@@ -1256,5 +1256,28 @@ describe('TemplateService', () => {
       chai.expect(created).to.include(uiBundleJson);
       chai.expect(created).to.include(uiBundleMetaXml);
     });
+
+    it('should create UIBundle (vuebasic)', async () => {
+      await remove(
+        path.join('testsoutput', 'libraryCreate', 'uiBundles')
+      );
+      const templateService = TemplateService.getInstance();
+      const result = await templateService.create(TemplateType.UIBundle, {
+        bundlename: 'LibraryCreateVueApp',
+        outputdir: path.join('testsoutput', 'libraryCreate', 'uiBundles'),
+        template: 'vuebasic',
+        internal: true,
+      });
+
+      const created = result.created.map((p) => path.normalize(p));
+      const uiBundleJson = path.normalize(
+        'testsoutput/libraryCreate/uiBundles/LibraryCreateVueApp/ui-bundle.json'
+      );
+      const uiBundleMetaXml = path.normalize(
+        'testsoutput/libraryCreate/uiBundles/LibraryCreateVueApp/LibraryCreateVueApp.uibundle-meta.xml'
+      );
+      chai.expect(created).to.include(uiBundleJson);
+      chai.expect(created).to.include(uiBundleMetaXml);
+    });
   });
 });

--- a/test/service/templateService.test.ts
+++ b/test/service/templateService.test.ts
@@ -1278,6 +1278,14 @@ describe('TemplateService', () => {
       );
       chai.expect(created).to.include(uiBundleJson);
       chai.expect(created).to.include(uiBundleMetaXml);
+
+      const metaContent = fs.readFileSync(uiBundleMetaXml, 'utf8');
+      chai.expect(metaContent).to.include('<isActive>true</isActive>');
+      chai.expect(metaContent).to.include('<version>1</version>');
+      chai
+        .expect(metaContent)
+        .to.include('<masterLabel>Library Create Vue App</masterLabel>');
+      chai.expect(metaContent).to.not.include('<type>');
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "./src/templates/lightningcomponent/lwc/typeScript/*",
     "./src/templates/uiBundles/reactbasic/**/*",
     "./src/templates/uiBundles/angularbasic/**/*",
+    "./src/templates/uiBundles/vuebasic/**/*",
     "./src/templates/project/reactinternalapp/**/*",
     "./src/templates/project/reactexternalapp/**/*"
   ]


### PR DESCRIPTION
## Add `vuebasic` generator to the UI Bundle template

Adds a `vuebasic` case to `@salesforce/templates`' UI-bundle generator so
`sf template generate ui-bundle --template vuebasic` scaffolds a Vue 3 app,
mirroring the existing `reactbasic` / `angularbasic` generators.

### Feature changes (already on the branch)
- `src/generators/uiBundleGenerator.ts` — new `generateVueBasic()` that renders
  `_uibundle.uibundle-meta.xml` (`{ apiVersion, masterLabel }`) and `package.json`
  (`{ bundlename }`), then recursively copies the rest of the scaffold excluding
  those two rendered files.
- `scripts/copy-templates.js` — copies `base-vue-app` into
  `src/templates/uiBundles/vuebasic/` at build time.
- `tsconfig.json` — excludes the vuebasic template sources from `tsc`.

### Tests added / strengthened in this PR
The existing `should create UIBundle (vuebasic)` test only asserted that the two
files appeared in the created set. This PR adds **content assertions** on the
rendered `*.uibundle-meta.xml` — the exact regression this feature fixed:
```ts
chai.expect(metaContent).to.include('<isActive>true</isActive>');
chai.expect(metaContent).to.include('<version>1</version>');
chai.expect(metaContent).to.include('<masterLabel>Library Create Vue App</masterLabel>');
chai.expect(metaContent).to.not.include('<type>');
```

### Verification
- `npx tsc -b && node scripts/copy-templates.js` → **green**
- `npx mocha … --grep vuebasic` → **1 passing**
- full `templateService` service suite → **44 passing / 0 failing**
