### PR TITLE
feat: add Lightning Out 2.0 template generator (Option A)

### DIFF
--- a/src/generators/lightningOutGenerator.ts
+++ b/src/generators/lightningOutGenerator.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import { nls } from '../i18n';
+import {
+  isAllowedLightningOutOrigin,
+  isValidMetadataName,
+  LIGHTNING_OUT_DISTRIBUTION_STATES,
+  LIGHTNING_OUT_IFRAME_CONTEXT,
+  LIGHTNING_OUT_RUNTIMES,
+  sanitizeOrigin,
+} from '../utils/lightningOut';
+import { LightningOutOptions } from '../utils/types';
+import { BaseGenerator } from './baseGenerator';
+
+const VALID_RUNTIMES: ReadonlySet<string> = new Set(LIGHTNING_OUT_RUNTIMES);
+const VALID_DIST_STATES: ReadonlySet<string> = new Set(
+  LIGHTNING_OUT_DISTRIBUTION_STATES
+);
+
+export default class LightningOutGenerator extends BaseGenerator<LightningOutOptions> {
+  public validateOptions(): void {
+    const errors: string[] = [];
+
+    if (!isValidMetadataName(this.options.name)) {
+      errors.push(nls.localize('InvalidLightningOutName'));
+    }
+    if (!VALID_RUNTIMES.has(this.options.runtime)) {
+      errors.push(
+        nls.localize('InvalidLightningOutRuntime', [
+          [...VALID_RUNTIMES].join(', '),
+        ])
+      );
+    }
+    if (
+      !Array.isArray(this.options.components) ||
+      this.options.components.length === 0
+    ) {
+      errors.push(nls.localize('MissingLightningOutComponents'));
+    }
+    if (
+      !Array.isArray(this.options.hostDomains) ||
+      this.options.hostDomains.length === 0
+    ) {
+      errors.push(nls.localize('MissingLightningOutHostDomains'));
+    } else {
+      const bad = this.options.hostDomains.filter(
+        (d) => !isAllowedLightningOutOrigin(d)
+      );
+      if (bad.length) {
+        errors.push(
+          nls.localize('InvalidLightningOutHostDomain', [bad.join(', ')])
+        );
+      }
+    }
+
+    const eca = this.options.eca;
+    if (
+      !eca ||
+      !eca.contactEmail ||
+      !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(eca.contactEmail)
+    ) {
+      errors.push(nls.localize('InvalidLightningOutContactEmail'));
+    }
+    if (
+      eca &&
+      eca.distributionState &&
+      !VALID_DIST_STATES.has(eca.distributionState)
+    ) {
+      errors.push(
+        nls.localize('InvalidLightningOutDistributionState', [
+          [...VALID_DIST_STATES].join(', '),
+        ])
+      );
+    }
+
+    if (errors.length) {
+      throw new Error(
+        nls.localize('InvalidLightningOutDefinition', [
+          '\n  - ' + errors.join('\n  - '),
+        ])
+      );
+    }
+  }
+
+  public async generate(): Promise<void> {
+    const { name, runtime, components, hostDomains, eca } = this.options;
+
+    this.sourceRootWithPartialPath(path.join('lightningout', 'default'));
+
+    // Option A guardrail: refuse to silently overwrite pre-existing files.
+    // Collect every destination we intend to write, and if any already exists
+    // (and --force was not passed) throw before writing anything.
+    this.assertNoSilentOverwrite();
+
+    // LightningOutApp
+    await this.render(
+      this.templatePath('lightningOutApp.xml'),
+      this.destinationPath(
+        path.join(this.outputdir, 'lightningOutApps', `${name}.lightningOutApp-meta.xml`)
+      ),
+      { name, runtime, components, hostDomains }
+    );
+
+    // IframeWhiteListUrlSettings — REPLACE-type on deploy. Because deploying this
+    // artifact REPLACES the org's entire "Trusted Domains for Inline Frames" list
+    // across every IFrame Type (Visualforce, Surveys, Lightning Out, etc.), this
+    // file lists only the app's host domains. The developer must review it against
+    // their org before deploying to avoid wiping existing cross-context entries.
+    const iframeEntries = hostDomains.map((url) => ({
+      url,
+      context: LIGHTNING_OUT_IFRAME_CONTEXT,
+    }));
+    await this.render(
+      this.templatePath('iframeWhiteListUrlSettings.xml'),
+      this.destinationPath(
+        path.join(
+          this.outputdir,
+          'iframeWhiteListUrlSettings',
+          'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+        )
+      ),
+      { iframeEntries }
+    );
+
+    // MyDomainSettings — server-side field merge (safe minimal file).
+    await this.render(
+      this.templatePath('myDomainSettings.xml'),
+      this.destinationPath(
+        path.join(this.outputdir, 'settings', 'MyDomain.settings-meta.xml')
+      ),
+      {}
+    );
+
+    // SecuritySettings — server-side field merge (safe minimal file).
+    await this.render(
+      this.templatePath('securitySettings.xml'),
+      this.destinationPath(
+        path.join(this.outputdir, 'settings', 'Security.settings-meta.xml')
+      ),
+      {}
+    );
+
+    // CorsWhitelistOrigin — one independent, per-origin file (never clobbers others).
+    for (const origin of hostDomains) {
+      await this.render(
+        this.templatePath('corsWhitelistOrigin.xml'),
+        this.destinationPath(
+          path.join(
+            this.outputdir,
+            'corsWhitelistOrigins',
+            `${sanitizeOrigin(origin)}.corsWhitelistOrigin-meta.xml`
+          )
+        ),
+        { origin }
+      );
+    }
+
+    // ExternalClientApplication + OAuth settings trio.
+    const distributionState = eca.distributionState ?? 'Local';
+    const callbackUrl = eca.callbackUrl ?? `${hostDomains[0]}/frontdoor-url.html`;
+    const oauthScopes = (eca.oauthScopes ?? ['Web']).join(', ');
+
+    await this.render(
+      this.templatePath('externalClientApplication.xml'),
+      this.destinationPath(
+        path.join(this.outputdir, 'externalClientApps', `${name}.eca-meta.xml`)
+      ),
+      { name, contactEmail: eca.contactEmail, distributionState }
+    );
+
+    await this.render(
+      this.templatePath('extlClntAppGlobalOauthSettings.xml'),
+      this.destinationPath(
+        path.join(
+          this.outputdir,
+          'extlClntAppGlobalOauthSets',
+          `${name}.ecaGlblOauth-meta.xml`
+        )
+      ),
+      { name, callbackUrl }
+    );
+
+    await this.render(
+      this.templatePath('extlClntAppOauthSettings.xml'),
+      this.destinationPath(
+        path.join(
+          this.outputdir,
+          'extlClntAppOauthSettings',
+          `${name}.ecaOauth-meta.xml`
+        )
+      ),
+      { name, oauthScopes }
+    );
+  }
+
+  /**
+   * Option A guardrail. Unless `force` is set, throw if any artifact we are
+   * about to write already exists on disk, so a re-run never silently
+   * overwrites a developer's edits (notably the REPLACE-type iframe file).
+   */
+  private assertNoSilentOverwrite(): void {
+    if (this.options.force) {
+      return;
+    }
+    const { name, hostDomains } = this.options;
+    const destinations = [
+      path.join(this.outputdir, 'lightningOutApps', `${name}.lightningOutApp-meta.xml`),
+      path.join(
+        this.outputdir,
+        'iframeWhiteListUrlSettings',
+        'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+      ),
+      path.join(this.outputdir, 'settings', 'MyDomain.settings-meta.xml'),
+      path.join(this.outputdir, 'settings', 'Security.settings-meta.xml'),
+      ...hostDomains.map((o) =>
+        path.join(
+          this.outputdir,
+          'corsWhitelistOrigins',
+          `${sanitizeOrigin(o)}.corsWhitelistOrigin-meta.xml`
+        )
+      ),
+      path.join(this.outputdir, 'externalClientApps', `${name}.eca-meta.xml`),
+      path.join(
+        this.outputdir,
+        'extlClntAppGlobalOauthSets',
+        `${name}.ecaGlblOauth-meta.xml`
+      ),
+      path.join(
+        this.outputdir,
+        'extlClntAppOauthSettings',
+        `${name}.ecaOauth-meta.xml`
+      ),
+    ];
+
+    const existing = destinations.filter((d) =>
+      this._fs.existsSync(this.destinationPath(d))
+    );
+    if (existing.length) {
+      throw new Error(
+        nls.localize('LightningOutFilesExist', [
+          existing.map((f) => `  - ${f}`).join('\n'),
+        ])
+      );
+    }
+  }
+}

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -77,4 +77,22 @@ export const messages = {
     'The --shell-title flag must not contain a double-quote character; it would break the generated HTML attribute.',
   UIEmbeddingBundle:
     'A Lightning Web Component that wraps the <lightning-ui-embedding> base component.',
+
+  InvalidLightningOutDefinition:
+    'The Lightning Out definition is invalid:%s',
+  InvalidLightningOutName:
+    'name must be a valid Metadata API name: start with a letter and contain only letters, numbers, and underscores.',
+  InvalidLightningOutRuntime: 'runtime must be one of: %s.',
+  MissingLightningOutComponents:
+    'components must be a non-empty array of Lightning web component names.',
+  MissingLightningOutHostDomains:
+    'hostDomains must be a non-empty array of https origins.',
+  InvalidLightningOutHostDomain:
+    'These hostDomains are not valid https origins: %s. Each must be an https URL with no spaces or wildcards (e.g., https://app.example.com).',
+  InvalidLightningOutContactEmail:
+    'eca.contactEmail is required and must be a valid email address.',
+  InvalidLightningOutDistributionState:
+    'eca.distributionState must be one of: %s.',
+  LightningOutFilesExist:
+    'The following files already exist and would be overwritten:\n%s\nRe-run with --force to overwrite them. Note: the IframeWhiteListUrlSettings file is REPLACE-type on deploy — overwriting it can wipe your org\'s Trusted Domains for Inline Frames list.',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export { validateCustomTemplate } from './generators/baseGenerator';
 export * from './utils/types';
 export * from './utils/createUtil';
 export * from './utils/uiEmbedding';
+export * from './utils/lightningOut';

--- a/src/templates/lightningout/default/corsWhitelistOrigin.xml
+++ b/src/templates/lightningout/default/corsWhitelistOrigin.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CorsWhitelistOrigin xmlns="http://soap.sforce.com/2006/04/metadata">
+    <urlPattern><%= origin %></urlPattern>
+</CorsWhitelistOrigin>

--- a/src/templates/lightningout/default/externalClientApplication.xml
+++ b/src/templates/lightningout/default/externalClientApplication.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExternalClientApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contactEmail><%= contactEmail %></contactEmail>
+    <description>Lightning Out 2.0 application <%= name %> (OAuth Auth-Code + PKCE, no client secret).</description>
+    <distributionState><%= distributionState %></distributionState>
+    <label><%= name %></label>
+</ExternalClientApplication>

--- a/src/templates/lightningout/default/extlClntAppGlobalOauthSettings.xml
+++ b/src/templates/lightningout/default/extlClntAppGlobalOauthSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExtlClntAppGlobalOauthSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <callbackUrl><%= callbackUrl %></callbackUrl>
+    <externalClientApplication><%= name %></externalClientApplication>
+    <label><%= name %> Global OAuth</label>
+</ExtlClntAppGlobalOauthSettings>

--- a/src/templates/lightningout/default/extlClntAppOauthSettings.xml
+++ b/src/templates/lightningout/default/extlClntAppOauthSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ExtlClntAppOauthSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <externalClientApplication><%= name %></externalClientApplication>
+    <label><%= name %> OAuth Settings</label>
+    <commaSeparatedOauthScopes><%= oauthScopes %></commaSeparatedOauthScopes>
+</ExtlClntAppOauthSettings>

--- a/src/templates/lightningout/default/iframeWhiteListUrlSettings.xml
+++ b/src/templates/lightningout/default/iframeWhiteListUrlSettings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  WARNING: Deploying IframeWhiteListUrlSettings REPLACES the org's ENTIRE
+  "Trusted Domains for Inline Frames" list (Setup > Security > Session Settings),
+  across all IFrame Types (Visualforce, Surveys, Lightning Out, UI Embedding).
+  Any pre-existing entries not listed in this file will be removed on deploy.
+  Review this list against your org before deploying.
+-->
+<IframeWhiteListUrlSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+<% iframeEntries.forEach(function (e) { -%>
+    <iframeWhiteListUrls>
+        <context><%= e.context %></context>
+        <url><%= e.url %></url>
+    </iframeWhiteListUrls>
+<% }); -%>
+</IframeWhiteListUrlSettings>

--- a/src/templates/lightningout/default/lightningOutApp.xml
+++ b/src/templates/lightningout/default/lightningOutApp.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningOutApp xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationName><%= name %></applicationName>
+    <isEnabled>true</isEnabled>
+    <runtime><%= runtime %></runtime>
+    <components>
+<% components.forEach(function (c) { -%>
+        <component>
+            <componentName><%= c %></componentName>
+        </component>
+<% }); -%>
+    </components>
+    <allowedDomains>
+<% hostDomains.forEach(function (d) { -%>
+        <domain>
+            <hostDomain><%= d %></hostDomain>
+        </domain>
+<% }); -%>
+    </allowedDomains>
+</LightningOutApp>

--- a/src/templates/lightningout/default/myDomainSettings.xml
+++ b/src/templates/lightningout/default/myDomainSettings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MyDomainSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <isFirstPartyCookieUseRequired>false</isFirstPartyCookieUseRequired>
+</MyDomainSettings>

--- a/src/templates/lightningout/default/securitySettings.xml
+++ b/src/templates/lightningout/default/securitySettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SecuritySettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <sessionSettings>
+        <enableOauthCorsPolicy>true</enableOauthCorsPolicy>
+    </sessionSettings>
+</SecuritySettings>

--- a/src/utils/lightningOut.ts
+++ b/src/utils/lightningOut.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Runtimes supported by a Lightning Out 2.0 app.
+ * Exposed so CLI plugins can derive their flag `options` list from a single source of truth.
+ */
+export const LIGHTNING_OUT_RUNTIMES = ['LWR_CORE', 'CLWR'] as const;
+export type LightningOutRuntime = (typeof LIGHTNING_OUT_RUNTIMES)[number];
+
+/**
+ * ExternalClientApplication distribution states.
+ */
+export const LIGHTNING_OUT_DISTRIBUTION_STATES = ['Local', 'Packaged'] as const;
+export type LightningOutDistributionState =
+  (typeof LIGHTNING_OUT_DISTRIBUTION_STATES)[number];
+
+/**
+ * Returns true if `origin` is an explicit https origin with no wildcard.
+ * Lightning Out host domains and CORS origins must be concrete https origins.
+ */
+export function isAllowedLightningOutOrigin(origin: string): boolean {
+  return typeof origin === 'string' && /^https:\/\/[^\s*]+$/.test(origin);
+}
+
+/**
+ * Returns true if `name` is a valid Metadata API name (letter, then
+ * alphanumerics/underscore).
+ */
+export function isValidMetadataName(name: string): boolean {
+  return typeof name === 'string' && /^[A-Za-z][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
+ * Sanitize an https origin into a Metadata-API-safe file/member name.
+ * Strips the scheme first (so we never emit a leading "https_" that the
+ * Metadata API misreads as a namespace prefix), then collapses any run of
+ * non-alphanumerics to a single '_' and trims leading/trailing underscores.
+ */
+export function sanitizeOrigin(origin: string): string {
+  return origin
+    .replace(/^https?:\/\//, '')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * IFrame Type (context) an IframeWhiteListUrl entry applies to. The org's
+ * "Trusted Domains for Inline Frames" list spans all of these; a deploy of
+ * IframeWhiteListUrlSettings REPLACES the entire list across every context.
+ */
+export const LIGHTNING_OUT_IFRAME_CONTEXT = 'LightningOut';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,6 +12,7 @@ import FlexipageGenerator from '../generators/flexipageGenerator';
 import LightningAppGenerator from '../generators/lightningAppGenerator';
 import LightningComponentGenerator from '../generators/lightningComponentGenerator';
 import UIEmbeddingGenerator from '../generators/uiEmbeddingGenerator';
+import LightningOutGenerator from '../generators/lightningOutGenerator';
 import LightningEventGenerator from '../generators/lightningEventGenerator';
 import LightningInterfaceGenerator from '../generators/lightningInterfaceGenerator';
 import LightningTestGenerator from '../generators/lightningTestGenerator';
@@ -53,6 +54,7 @@ export type Generators =
   | typeof LightningInterfaceGenerator
   | typeof DigitalExperienceSiteGenerator
   | typeof UIEmbeddingGenerator
+  | typeof LightningOutGenerator
   | typeof ProjectGenerator
   | typeof StaticResourceGenerator
   | typeof VisualforceComponentGenerator
@@ -78,6 +80,7 @@ export enum TemplateType {
   LightningTest,
   DigitalExperienceSite,
   UIEmbedding,
+  LightningOut,
   Project,
   VisualforceComponent,
   VisualforcePage,
@@ -97,6 +100,7 @@ export const generators = new Map<TemplateType, GeneratorClass<any>>([
   [TemplateType.LightningTest, LightningTestGenerator],
   [TemplateType.DigitalExperienceSite, DigitalExperienceSiteGenerator],
   [TemplateType.UIEmbedding, UIEmbeddingGenerator],
+  [TemplateType.LightningOut, LightningOutGenerator],
   [TemplateType.Project, ProjectGenerator],
   [TemplateType.StaticResource, StaticResourceGenerator],
   [TemplateType.VisualforceComponent, VisualforceComponentGenerator],
@@ -202,6 +206,32 @@ export interface UIEmbeddingOptions extends TemplateOptions {
   sandbox: string;
   shellTitle: string;
   internal: boolean;
+}
+
+export interface LightningOutEcaOptions {
+  contactEmail: string;
+  distributionState?: 'Local' | 'Packaged';
+  callbackUrl?: string;
+  oauthScopes?: string[];
+}
+
+export interface LightningOutOptions extends TemplateOptions {
+  /** Metadata API name of the Lightning Out app (also the ECA/OAuth member name). */
+  name: string;
+  /** LWR_CORE or CLWR. */
+  runtime: 'LWR_CORE' | 'CLWR';
+  /** LWC component names exposed by the app (e.g. "c-my-button"). */
+  components: string[];
+  /** Explicit https origins of the external host pages that embed the app. */
+  hostDomains: string[];
+  /** External Client Application (OAuth) settings. */
+  eca: LightningOutEcaOptions;
+  /**
+   * Overwrite existing files without erroring. Off by default: if a target
+   * file already exists with different content, generate() throws rather than
+   * silently clobbering it (Option A — no silent overwrite).
+   */
+  force?: boolean;
 }
 
 export interface ProjectOptions extends TemplateOptions {

--- a/test/generators/lightningOutGenerator.test.ts
+++ b/test/generators/lightningOutGenerator.test.ts
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as chai from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { TemplateService, TemplateType } from '../../src';
+import LightningOutGenerator from '../../src/generators/lightningOutGenerator';
+import { getDefaultApiVersion } from '../../src/generators/baseGenerator';
+import { LightningOutOptions } from '../../src/utils/types';
+
+chai.config.truncateThreshold = 100000;
+const { expect } = chai;
+
+async function remove(file: string) {
+  await fs.promises.rm(file, { force: true, recursive: true });
+}
+
+function assertFileExists(file: string) {
+  expect(fs.existsSync(file), `Expected file to exist: ${file}`).to.be.true;
+}
+
+function assertFileContent(file: string, needle: string | RegExp) {
+  assertFileExists(file);
+  const body = fs.readFileSync(file, 'utf8');
+  const match =
+    typeof needle === 'string' ? body.includes(needle) : needle.test(body);
+  expect(match, `${file} did not match '${needle}'. Contained:\n\n${body}`).to
+    .be.true;
+}
+
+const baseOpts = (
+  outputdir: string,
+  overrides: Partial<LightningOutOptions> = {}
+): LightningOutOptions => ({
+  name: 'MyLoApp',
+  runtime: 'LWR_CORE',
+  components: ['c-my-button'],
+  hostDomains: ['https://app.example.com'],
+  eca: { contactEmail: 'dev@example.com' },
+  outputdir,
+  apiversion: getDefaultApiVersion(),
+  ...overrides,
+});
+
+describe('LightningOutGenerator', () => {
+  const outputDir = path.join('testsoutput', 'lightningout');
+
+  beforeEach(async () => {
+    await remove(outputDir);
+  });
+
+  after(async () => {
+    await remove(outputDir);
+  });
+
+  describe('validateOptions', () => {
+    it('should throw when name is not a valid metadata name', () => {
+      expect(
+        () => new LightningOutGenerator(baseOpts(outputDir, { name: '9bad' }))
+      ).to.throw(/name/i);
+    });
+
+    it('should throw when runtime is not LWR_CORE or CLWR', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, {
+              runtime: 'NOPE' as LightningOutOptions['runtime'],
+            })
+          )
+      ).to.throw(/runtime/i);
+    });
+
+    it('should throw when components is empty', () => {
+      expect(
+        () => new LightningOutGenerator(baseOpts(outputDir, { components: [] }))
+      ).to.throw(/components/i);
+    });
+
+    it('should throw when hostDomains is empty', () => {
+      expect(
+        () => new LightningOutGenerator(baseOpts(outputDir, { hostDomains: [] }))
+      ).to.throw(/hostDomains/i);
+    });
+
+    it('should throw when a hostDomain is not an https origin', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, {
+              hostDomains: ['http://app.example.com'],
+            })
+          )
+      ).to.throw(/https/i);
+    });
+
+    it('should throw when a hostDomain contains a wildcard', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, {
+              hostDomains: ['https://*.example.com'],
+            })
+          )
+      ).to.throw(/https/i);
+    });
+
+    it('should throw when contactEmail is missing or invalid', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, {
+              eca: { contactEmail: 'not-an-email' },
+            })
+          )
+      ).to.throw(/contactEmail/i);
+    });
+
+    it('should throw when distributionState is invalid', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, {
+              eca: {
+                contactEmail: 'dev@example.com',
+                distributionState:
+                  'Bogus' as LightningOutOptions['eca']['distributionState'],
+              },
+            })
+          )
+      ).to.throw(/distributionState/i);
+    });
+
+    it('should accept a valid CLWR definition', () => {
+      expect(
+        () =>
+          new LightningOutGenerator(
+            baseOpts(outputDir, { runtime: 'CLWR' })
+          )
+      ).to.not.throw();
+    });
+  });
+
+  describe('generate', () => {
+    it('should emit all seven artifact types', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      const result = await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir, {
+          hostDomains: ['https://app.example.com', 'https://portal.example.com'],
+        })
+      );
+
+      assertFileExists(
+        path.join(
+          outputDir,
+          'lightningOutApps',
+          'MyLoApp.lightningOutApp-meta.xml'
+        )
+      );
+      assertFileExists(
+        path.join(
+          outputDir,
+          'iframeWhiteListUrlSettings',
+          'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+        )
+      );
+      assertFileExists(
+        path.join(outputDir, 'settings', 'MyDomain.settings-meta.xml')
+      );
+      assertFileExists(
+        path.join(outputDir, 'settings', 'Security.settings-meta.xml')
+      );
+      assertFileExists(
+        path.join(outputDir, 'externalClientApps', 'MyLoApp.eca-meta.xml')
+      );
+      assertFileExists(
+        path.join(
+          outputDir,
+          'extlClntAppGlobalOauthSets',
+          'MyLoApp.ecaGlblOauth-meta.xml'
+        )
+      );
+      assertFileExists(
+        path.join(
+          outputDir,
+          'extlClntAppOauthSettings',
+          'MyLoApp.ecaOauth-meta.xml'
+        )
+      );
+
+      // One CORS file per host domain, named by sanitized origin.
+      assertFileExists(
+        path.join(
+          outputDir,
+          'corsWhitelistOrigins',
+          'app_example_com.corsWhitelistOrigin-meta.xml'
+        )
+      );
+      assertFileExists(
+        path.join(
+          outputDir,
+          'corsWhitelistOrigins',
+          'portal_example_com.corsWhitelistOrigin-meta.xml'
+        )
+      );
+
+      expect(result.created.length).to.be.greaterThan(0);
+    });
+
+    it('should render the app name and runtime into the LightningOutApp', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir, { runtime: 'CLWR', components: ['c-foo', 'c-bar'] })
+      );
+      const app = path.join(
+        outputDir,
+        'lightningOutApps',
+        'MyLoApp.lightningOutApp-meta.xml'
+      );
+      assertFileContent(app, 'CLWR');
+      assertFileContent(app, 'c-foo');
+      assertFileContent(app, 'c-bar');
+    });
+
+    it('should not emit a double-hyphen inside the iframe XML comment (invalid XML — rejected by deploy)', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir)
+      );
+      const iframe = path.join(
+        outputDir,
+        'iframeWhiteListUrlSettings',
+        'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+      );
+      const body = fs.readFileSync(iframe, 'utf8');
+      const commentMatch = body.match(/<!--[\s\S]*?-->/);
+      expect(commentMatch, 'iframe file should contain an XML comment').to.not.be
+        .null;
+      const inner = commentMatch![0].slice(4, -3); // strip <!-- and -->
+      expect(inner, 'XML comments must not contain "--"').to.not.match(/--/);
+    });
+
+    it('should include the WARNING comment in the iframe artifact', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir)
+      );
+      assertFileContent(
+        path.join(
+          outputDir,
+          'iframeWhiteListUrlSettings',
+          'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+        ),
+        /WARNING/i
+      );
+    });
+
+    it('should list only the app host domains in the iframe artifact by default', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir, { hostDomains: ['https://app.example.com'] })
+      );
+      const iframe = path.join(
+        outputDir,
+        'iframeWhiteListUrlSettings',
+        'IframeWhiteListUrlSettings.iframeWhiteListUrlSettings-meta.xml'
+      );
+      assertFileContent(iframe, 'https://app.example.com');
+    });
+  });
+
+  describe('Option A — no silent overwrite', () => {
+    it('should throw if a target file already exists and force is not set', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir)
+      );
+      // Second run against the same dir must refuse to clobber.
+      let threw: Error | undefined;
+      try {
+        await templateService.create(
+          TemplateType.LightningOut,
+          baseOpts(outputDir)
+        );
+      } catch (e) {
+        threw = e as Error;
+      }
+      expect(threw, 'expected a throw on second run').to.be.instanceOf(Error);
+      expect(threw!.message).to.match(/already exist/i);
+    });
+
+    it('should overwrite without error when force is true', async () => {
+      const templateService = TemplateService.getInstance(process.cwd());
+      await templateService.create(
+        TemplateType.LightningOut,
+        baseOpts(outputDir)
+      );
+      let threw: Error | undefined;
+      try {
+        await templateService.create(
+          TemplateType.LightningOut,
+          baseOpts(outputDir, { force: true })
+        );
+      } catch (e) {
+        threw = e as Error;
+      }
+      expect(threw, 'force:true should not throw').to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
# feat: add Lightning Out 2.0 template generator

**Repo:** forcedotcom/salesforcedx-templates
**State:** DRAFT — LO 2.0 (release 266) scaffolding spike POC

**Stacked as two PRs:**
- **PR 1 (Option A):** `lo2/lightning-out` (base: `main` @ 7326ba4, commit `ad79193`) — the full scaffold + guardrail + REPLACE warning.
- **PR 2 (Option B):** `lo2/lightning-out-merge` (base: `lo2/lightning-out`, commit `42fc454`) — adds *only* the `mergeIframeEntries` / `existingIframeEntries` slice (5-file delta). Review after PR 1.

## What

Adds a `LightningOut` template type that scaffolds the seven metadata artifacts a
Lightning Out 2.0 app requires:

| Artifact | Deploy merge behavior |
|----------|----------------------|
| LightningOutApp | uniquely named — safe |
| MyDomainSettings | field-level merge — safe |
| SecuritySettings | field-level merge — safe |
| CorsWhitelistOrigin (one per host domain) | per-object independent — safe |
| ExternalClientApplication + 2 OAuth settings | uniquely named — safe |
| **IframeWhiteListUrlSettings** | **LIST REPLACE — the risk** |

## The IframeWhiteListUrlSettings risk

Deploying `IframeWhiteListUrlSettings` REPLACES the org's entire "Trusted Domains
for Inline Frames" list (Setup → Security → Session Settings), across *all* IFrame
Types (Visualforce, Surveys, Lightning Out, UI Embedding). MDAPI append/upsert is
not supported (confirmed empirically + via Product Defense). This POC mitigates it
two ways:

- **Option A (default):** the generated file lists only this app's host domains and
  carries a prominent WARNING comment. `generate()` refuses to silently overwrite an
  existing file unless `force` is set — a re-run can't clobber a developer's edits.
- **Option B (opt-in):** the generator accepts `existingIframeEntries` (retrieved by
  the command layer) and re-emits every existing entry verbatim — preserving each
  entry's context across all IFrame Types — then adds this app's LightningOut
  domains. The library never talks to an org.

## Files

- `src/utils/lightningOut.ts` — validators, `sanitizeOrigin`, `mergeIframeEntries`
- `src/generators/lightningOutGenerator.ts` — the generator
- `src/templates/lightningout/default/*.xml` — 8 EJS templates
- `src/utils/types.ts`, `src/i18n/i18n.ts`, `src/index.ts` — wiring
- `test/generators/lightningOutGenerator.test.ts` — 17 unit tests

## Testing

- 17 new unit tests (validation, all-artifact emission, Option A guardrail + force,
  Option B merge/context-preservation, XML-comment validity regression).
- Full library suite: **214 passing**. Lint clean.
- Live-org validation (via the companion plugin-templates command): Option B
  retrieve→merge→deploy→re-retrieve preserved a pre-existing org entry through a
  REPLACE-type deploy (3/3 domains survived).
